### PR TITLE
Minor renames and move DependencyDeclaration to own file

### DIFF
--- a/sort/src/main/kotlin/com/squareup/sort/ConfigurationComparator.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/ConfigurationComparator.kt
@@ -1,7 +1,7 @@
 package com.squareup.sort
 
 internal object ConfigurationComparator :
-  Comparator<MutableMap.MutableEntry<String, MutableList<CtxDependency>>> {
+  Comparator<MutableMap.MutableEntry<String, MutableList<DependencyDeclaration>>> {
 
   private class Configuration(
     private val configuration: String,
@@ -36,35 +36,38 @@ internal object ConfigurationComparator :
         }
 
         // Try to find an exact match
-        var c = findConfiguration { it.first == configuration }
+        var matchingConfiguration = findConfiguration { it.first == configuration }
 
         // If that failed, look for a variant
-        if (c == null) {
-          c = findConfiguration { configuration.endsWith(it.first, true) }
-          if (c != null) {
-            c.variant = configuration.substring(0, configuration.length - c.configuration.length)
+        if (matchingConfiguration == null) {
+          matchingConfiguration = findConfiguration { configuration.endsWith(it.first, true) }
+          if (matchingConfiguration != null) {
+            matchingConfiguration.variant = configuration.substring(
+              0,
+              configuration.length - matchingConfiguration.configuration.length
+            )
           }
         }
 
         // Look for a variant again
-        if (c == null) {
-          c = findConfiguration { configuration.startsWith(it.first, true) }
-          if (c != null) {
-            c.variant = configuration.substring(
-              configuration.length - c.configuration.length,
+        if (matchingConfiguration == null) {
+          matchingConfiguration = findConfiguration { configuration.startsWith(it.first, true) }
+          if (matchingConfiguration != null) {
+            matchingConfiguration.variant = configuration.substring(
+              configuration.length - matchingConfiguration.configuration.length,
               configuration.length
             )
           }
         }
 
-        return c
+        return matchingConfiguration
       }
     }
   }
 
   override fun compare(
-    left: MutableMap.MutableEntry<String, MutableList<CtxDependency>>,
-    right: MutableMap.MutableEntry<String, MutableList<CtxDependency>>
+    left: MutableMap.MutableEntry<String, MutableList<DependencyDeclaration>>,
+    right: MutableMap.MutableEntry<String, MutableList<DependencyDeclaration>>
   ): Int = stringCompare(left.key, right.key)
 
   /** Visible for testing. */

--- a/sort/src/main/kotlin/com/squareup/sort/DependencyComparator.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/DependencyComparator.kt
@@ -5,11 +5,11 @@ import org.antlr.v4.runtime.CommonTokenStream
 
 internal class DependencyComparator(
   private val tokens: CommonTokenStream
-) : Comparator<CtxDependency> {
+) : Comparator<DependencyDeclaration> {
 
   override fun compare(
-    left: CtxDependency,
-    right: CtxDependency
+    left: DependencyDeclaration,
+    right: DependencyDeclaration
   ): Int {
     if (left.isPlatformDeclaration() && right.isPlatformDeclaration()) return compareDeclaration(left, right)
     if (left.isPlatformDeclaration()) return -1
@@ -23,8 +23,8 @@ internal class DependencyComparator(
   }
 
   private fun compareDeclaration(
-    left: CtxDependency,
-    right: CtxDependency
+    left: DependencyDeclaration,
+    right: DependencyDeclaration
   ): Int {
     if (left.isProjectDependency() && right.isProjectDependency()) return compareDependencies(left, right)
     if (left.isProjectDependency()) return -1
@@ -38,8 +38,8 @@ internal class DependencyComparator(
   }
 
   private fun compareDependencies(
-    left: CtxDependency,
-    right: CtxDependency
+    left: DependencyDeclaration,
+    right: DependencyDeclaration
   ): Int {
     // Colons should sort "higher" than hyphens. The comma's ascii value is 44, the hyphen's is 45, and
     // the colon's is 58. We replace colons with commas and then rely on natural sort order from there.
@@ -67,7 +67,7 @@ internal class DependencyComparator(
    *
    * We want 2 to be sorted above 1. This is arbitrary.
    */
-  private fun CtxDependency.hasQuotes(): Boolean {
+  private fun DependencyDeclaration.hasQuotes(): Boolean {
     val i = declaration.children.indexOf(dependency)
     return declaration.getChild(i - 1) is QuoteContext && declaration.getChild(i + 1) is QuoteContext
   }

--- a/sort/src/main/kotlin/com/squareup/sort/DependencyDeclaration.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/DependencyDeclaration.kt
@@ -1,0 +1,62 @@
+package com.squareup.sort
+
+import com.squareup.grammar.GradleGroovyScript.DependencyContext
+import com.squareup.grammar.GradleGroovyScript.NormalDeclarationContext
+import com.squareup.grammar.GradleGroovyScript.PlatformDeclarationContext
+import com.squareup.grammar.GradleGroovyScript.TestFixturesDeclarationContext
+import org.antlr.v4.runtime.ParserRuleContext
+
+/**
+ * To sort a dependency declaration, we care what kind of declaration it is ("normal", "platform", "test fixtures"), as
+ * well as what kind of dependency it is (GAV, project, file/files, catalog-like).
+ */
+internal class DependencyDeclaration(
+    val declaration: ParserRuleContext,
+    val dependency: DependencyContext,
+    private val declarationKind: DeclarationKind,
+    private val dependencyKind: DependencyKind,
+) {
+
+  enum class DeclarationKind {
+    NORMAL, PLATFORM, TEST_FIXTURES
+  }
+
+  enum class DependencyKind {
+    NORMAL, PROJECT, FILE;
+
+    companion object {
+      fun of(dependency: DependencyContext): DependencyKind {
+        return if (dependency.externalDependency() != null) NORMAL
+        else if (dependency.projectDependency() != null) PROJECT
+        else if (dependency.fileDependency() != null) FILE
+        else error("Unknown dependency kind. Was ${dependency.text}.")
+      }
+    }
+  }
+
+  fun isPlatformDeclaration() = declarationKind == DeclarationKind.PLATFORM
+  fun isTestFixturesDeclaration() = declarationKind == DeclarationKind.TEST_FIXTURES
+
+  fun isProjectDependency() = dependencyKind == DependencyKind.PROJECT
+  fun isFileDependency() = dependencyKind == DependencyKind.FILE
+
+  companion object {
+    fun of(declaration: ParserRuleContext): DependencyDeclaration {
+      val (dependency, declarationKind) = when (declaration) {
+        is NormalDeclarationContext -> declaration.dependency() to DeclarationKind.NORMAL
+        is PlatformDeclarationContext -> declaration.dependency() to DeclarationKind.PLATFORM
+        is TestFixturesDeclarationContext -> declaration.dependency() to DeclarationKind.TEST_FIXTURES
+        else -> error("Unknown declaration kind. Was ${declaration.text}.")
+      }
+
+      val dependencyKind = when (declaration) {
+        is NormalDeclarationContext -> DependencyKind.of(declaration.dependency())
+        is PlatformDeclarationContext -> DependencyKind.of(declaration.dependency())
+        is TestFixturesDeclarationContext -> DependencyKind.of(declaration.dependency())
+        else -> error("Unknown declaration kind. Was ${declaration.text}.")
+      }
+
+      return DependencyDeclaration(declaration, dependency, declarationKind, dependencyKind)
+    }
+  }
+}


### PR DESCRIPTION
Just a couple changes that I felt would help a little with readability. Mainly `CtxDependency` -> `DependencyDeclaration` since we also have `DependencyContext` from the ANTLR generated code.