### PR TITLE
Replace illegal char on Windows

### DIFF
--- a/app/src/main/kotlin/com/squareup/sort/main.kt
+++ b/app/src/main/kotlin/com/squareup/sort/main.kt
@@ -30,7 +30,7 @@ private fun logger(fileSystem: FileSystem): DelegatingLogger {
     System.getProperty("java.io.tmpdir"),
     "dependencies-sorter"
   ).createDirectories()
-  val logFile = Files.createFile(logDir.resolve("${Instant.now()}.log"))
+  val logFile = Files.createFile(logDir.resolve("${Instant.now().toString().replace(":", "-")}.log"))
 
   return DelegatingLogger(
     delegate = LoggerFactory.getLogger("Sorter"),


### PR DESCRIPTION
This produces this kind of values: `2022-11-25T20-07-30.843646500Z`

Fixes #10