### PR TITLE
Add --quiet argument

### DIFF
--- a/app/src/main/kotlin/com/squareup/log/DelegatingLogger.kt
+++ b/app/src/main/kotlin/com/squareup/log/DelegatingLogger.kt
@@ -7,33 +7,46 @@ import kotlin.io.path.pathString
 
 class DelegatingLogger(
   private val delegate: Logger,
-  private val file: Path
+  private val file: Path,
+  private val quiet: Boolean
 ) : AutoCloseable, Logger by delegate {
 
   private val start = System.currentTimeMillis()
+  private var hasErrors = false
 
   override fun close() {
     val duration = System.currentTimeMillis() - start
-    delegate.info("Operation took $duration ms")
-    delegate.info("See log file at ${file.pathString} ")
+    if (!quiet) {
+      delegate.info("Operation took $duration ms")
+    }
+    if (hasErrors || !quiet) {
+      delegate.info("See log file at ${file.pathString} ")
+    }
   }
 
   override fun info(msg: String) {
     file.appendLine("INFO: $msg")
-    delegate.info(msg)
+    if (!quiet) {
+      delegate.info(msg)
+    }
   }
 
   override fun trace(msg: String) {
     file.appendLine("TRACE: $msg")
-    delegate.trace(msg)
+    if (!quiet) {
+      delegate.trace(msg)
+    }
   }
 
   override fun warn(msg: String) {
     file.appendLine("WARN: $msg")
-    delegate.trace(msg)
+    if (!quiet) {
+      delegate.trace(msg)
+    }
   }
 
   override fun error(msg: String) {
+    hasErrors = true
     file.appendLine("ERROR: $msg")
     delegate.error(msg)
   }
@@ -42,6 +55,7 @@ class DelegatingLogger(
     msg: String,
     t: Throwable
   ) {
+    hasErrors = true
     file.appendLine("ERROR: $msg, ${t.localizedMessage}")
     delegate.error(msg, t)
   }

--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -225,7 +225,7 @@ private fun logger(fileSystem: FileSystem, quiet: Boolean): DelegatingLogger {
     System.getProperty("java.io.tmpdir"),
     "dependencies-sorter"
   ).createDirectories()
-  val logFile = Files.createFile(logDir.resolve("${Instant.now()}.log"))
+  val logFile = Files.createFile(logDir.resolve("${Instant.now().toString().replace(":", "-")}.log"))
 
   return DelegatingLogger(
     delegate = LoggerFactory.getLogger("Sorter"),

--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -1,5 +1,6 @@
 package com.squareup.sort
 
+import com.squareup.log.DelegatingLogger
 import com.squareup.parse.AlreadyOrderedException
 import com.squareup.parse.BuildScriptParseException
 import com.squareup.sort.Status.NOT_SORTED
@@ -8,14 +9,20 @@ import com.squareup.sort.Status.NO_PATH_PASSED
 import com.squareup.sort.Status.SUCCESS
 import com.squareup.sort.Status.UNKNOWN_MODE
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.event.Level
 import picocli.CommandLine.Command
 import picocli.CommandLine.HelpCommand
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.time.Instant
 import java.util.concurrent.Callable
+import kotlin.io.path.createDirectories
 import kotlin.io.path.pathString
 import kotlin.io.path.writeText
 
@@ -35,10 +42,20 @@ import kotlin.io.path.writeText
   ]
 )
 class SortCommand(
-  private val logger: Logger,
-  private val fileSystem: FileSystem,
+  private val fileSystem: FileSystem = FileSystems.getDefault(),
   private val buildFileFinder: BuildDotGradleFinder.Factory = object : BuildDotGradleFinder.Factory {}
 ) : Callable<Int> {
+
+  private lateinit var logger: Logger
+
+  @Option(
+    names = ["-q", "--quiet"],
+    description = [
+      "Quiet mode. Only print errors. Logs are still written to a log file."
+    ],
+    defaultValue = "false"
+  )
+  var quiet: Boolean = false
 
   @Option(
     names = ["-m", "--mode"],
@@ -56,6 +73,7 @@ class SortCommand(
   lateinit var paths: List<String>
 
   override fun call(): Int {
+    logger = logger(fileSystem, quiet)
     if (!this::paths.isInitialized) {
       logger.error("No paths were passed. See 'help' for usage information.")
       return NO_PATH_PASSED.value
@@ -200,4 +218,18 @@ enum class Status(val value: Int) {
   NOT_SORTED(3),
   UNKNOWN_MODE(4),
   ;
+}
+
+private fun logger(fileSystem: FileSystem, quiet: Boolean): DelegatingLogger {
+  val logDir = fileSystem.getPath(
+    System.getProperty("java.io.tmpdir"),
+    "dependencies-sorter"
+  ).createDirectories()
+  val logFile = Files.createFile(logDir.resolve("${Instant.now()}.log"))
+
+  return DelegatingLogger(
+    delegate = LoggerFactory.getLogger("Sorter"),
+    file = logFile,
+    quiet = quiet,
+  )
 }

--- a/app/src/main/kotlin/com/squareup/sort/main.kt
+++ b/app/src/main/kotlin/com/squareup/sort/main.kt
@@ -11,29 +11,7 @@ import kotlin.io.path.createDirectories
 import kotlin.system.exitProcess
 
 fun main(vararg args: String) {
-  val fileSystem = FileSystems.getDefault()
-
-  val exitCode = logger(fileSystem).use { logger ->
-    val cli = CommandLine(
-      SortCommand(
-        logger = logger,
-        fileSystem = fileSystem
-      )
-    )
-    cli.execute(*args)
-  }
+  val cli = CommandLine(SortCommand())
+  val exitCode = cli.execute(*args)
   exitProcess(exitCode)
-}
-
-private fun logger(fileSystem: FileSystem): DelegatingLogger {
-  val logDir = fileSystem.getPath(
-    System.getProperty("java.io.tmpdir"),
-    "dependencies-sorter"
-  ).createDirectories()
-  val logFile = Files.createFile(logDir.resolve("${Instant.now()}.log"))
-
-  return DelegatingLogger(
-    delegate = LoggerFactory.getLogger("Sorter"),
-    file = logFile
-  )
 }

--- a/app/src/test/groovy/com/squareup/SortCommandSpec.groovy
+++ b/app/src/test/groovy/com/squareup/SortCommandSpec.groovy
@@ -20,15 +20,14 @@ final class SortCommandSpec extends Specification {
     def commandLine = new CommandLine(newSortCommand())
 
     when:
-    def parseResult = commandLine.parseArgs('-m', 'check')
+    def parseResult = commandLine.parseArgs('-m', 'check', '-q')
 
     then:
-    parseResult.expandedArgs() == ['-m', 'check']
+    parseResult.expandedArgs() == ['-m', 'check', '-q']
   }
 
   private SortCommand newSortCommand() {
     return new SortCommand(
-      LoggerFactory.getLogger("Sorter"),
       FileSystems.getDefault(),
       Stub(BuildDotGradleFinder.Factory)
     )


### PR DESCRIPTION
This adds a new `--quiet` argument to suppress noisy output unless there is an error. Logs are still recorded and written to the file, but only error outputs are printed and the log file location is printed if any errors were recorded.

Resolves #26