### PR TITLE
Add a basic `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Taken from other Square projects.
Open to add other configs for `[*.{kt, kts}]` if needed.