### PR TITLE
Add version badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This JVM CLI app and companion Gradle plugin can sort the dependencies of a `bui
 
 #### Apply it
 
+![Maven Central](https://img.shields.io/maven-central/v/com.squareup.sort-dependencies/com.squareup.sort-dependencies.gradle.plugin)
+
 ```groovy
 // build.gradle[.kts]
 plugins {


### PR DESCRIPTION
This helps users know the latest version more easily than going to the [tags page](https://github.com/square/gradle-dependencies-sorter/tags).

Beware, this solution uses the third party service [shields.io](https://shields.io/) to render the image.