### PR TITLE
Ignore local.properties and ANTLR codegen dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,13 @@
 # Ignore Gradle build output directory
 build
 
+# Ignore local Gradle properties file
+local.properties
+
 # Ignore generated antlr files
-*/src/main/gen
+*/src/main/**/gen
 *.tokens
 
 # Ignore IntelliJ project files
 .idea
+


### PR DESCRIPTION
Code is generated to `grammar/src/main/antlr/com/squareup/grammar/gen`, but the path glob didn't catch it.

local.properties should be ignored.