### PR TITLE
Tolerate project declarations in text blocks

### DIFF
--- a/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
+++ b/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
@@ -77,6 +77,7 @@ text
     | PARENS_OPEN
     | PARENS_CLOSE
     | BACKSLASH
+    | PROJECT
     ;
 
 // Sea of crap I don't care about

--- a/grammar/src/test/groovy/com/squareup/grammar/SimpleANTLRErrorListener.groovy
+++ b/grammar/src/test/groovy/com/squareup/grammar/SimpleANTLRErrorListener.groovy
@@ -1,0 +1,34 @@
+package com.squareup.grammar
+
+import org.antlr.v4.runtime.ANTLRErrorListener
+import org.antlr.v4.runtime.Parser
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+import org.antlr.v4.runtime.atn.ATNConfigSet
+import org.antlr.v4.runtime.atn.ATNSimulator
+import org.antlr.v4.runtime.dfa.DFA
+
+final class SimpleANTLRErrorListener implements ANTLRErrorListener {
+  private Closure<RuntimeException> onError
+
+  SimpleANTLRErrorListener(Closure<RuntimeException> onError) {
+    this.onError = onError;
+  }
+
+  @Override
+  void syntaxError(Recognizer<?, ? extends ATNSimulator> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
+    onError.call(new GroovyRuntimeException("Syntax error: $msg"))
+  }
+
+  @Override
+  void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, boolean exact, BitSet ambigAlts, ATNConfigSet configs) {
+  }
+
+  @Override
+  void reportAttemptingFullContext(Parser recognizer, DFA dfa, int startIndex, int stopIndex, BitSet conflictingAlts, ATNConfigSet configs) {
+  }
+
+  @Override
+  void reportContextSensitivity(Parser recognizer, DFA dfa, int startIndex, int stopIndex, int prediction, ATNConfigSet configs) {
+  }
+}


### PR DESCRIPTION
It is possible for build scripts to contain `project('...')` declarations in locations other than the `dependencies { /* ... */ }` and `buildscript { /* ... */ }` blocks.

For example, a plugin may support arbitrary configuration in top-level block like this:

```groovy
myVendorBlock {
    applicableProjects = [ project(':foo:bar') ]
}
```

The Gradle Dependencies Sorter won't (and shouldn't!) know how to sort such things, since it won't have knowledge of vendor syntax. However, the sorter should just skip these blocks instead of complaining about syntax.

Resolves: https://github.com/square/gradle-dependencies-sorter/issues/36