### PR TITLE
Add thread safety for log file creation

### DIFF
--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -18,12 +18,10 @@ import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import java.time.Instant
 import java.util.concurrent.Callable
-import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempFile
 import kotlin.io.path.pathString
 import kotlin.io.path.writeText
 
@@ -74,7 +72,7 @@ class SortCommand(
   lateinit var paths: List<String>
 
   override fun call(): Int {
-    logger = logger(fileSystem, quiet)
+    logger = logger(quiet)
     if (!this::paths.isInitialized) {
       logger.error("No paths were passed. See 'help' for usage information.")
       return NO_PATH_PASSED.value
@@ -228,22 +226,10 @@ enum class Status(val value: Int) {
   ;
 }
 
-private fun logger(fileSystem: FileSystem, quiet: Boolean): DelegatingLogger {
-  val logDir = fileSystem.getPath(
-    System.getProperty("java.io.tmpdir"),
-    "dependencies-sorter"
-  ).createDirectories()
-
-  var logFile: Path? = null
-  while (logFile == null) {
-    try {
-      logFile = Files.createFile(logDir.resolve("${Instant.now().toString().replace(":", "-")}.log"))
-    } catch (_: FileAlreadyExistsException) { }
-  }
-
+private fun logger(quiet: Boolean): DelegatingLogger {
   return DelegatingLogger(
     delegate = LoggerFactory.getLogger("Sorter"),
-    file = logFile,
+    file = createTempFile(),
     quiet = quiet,
   )
 }

--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -233,7 +233,13 @@ private fun logger(fileSystem: FileSystem, quiet: Boolean): DelegatingLogger {
     System.getProperty("java.io.tmpdir"),
     "dependencies-sorter"
   ).createDirectories()
-  val logFile = Files.createFile(logDir.resolve("${Instant.now().toString().replace(":", "-")}.log"))
+
+  var logFile: Path? = null
+  while (logFile == null) {
+    try {
+      logFile = Files.createFile(logDir.resolve("${Instant.now().toString().replace(":", "-")}.log"))
+    } catch (_: FileAlreadyExistsException) { }
+  }
 
   return DelegatingLogger(
     delegate = LoggerFactory.getLogger("Sorter"),


### PR DESCRIPTION
We run into the `FileAlreadyExistsException` during log file creation in about 1% of our CI builds with 16 workers. Though  rare it is a consistent occurrence over the past month and every time it happens we would need to rerun the task. Adding thread safety in the log file creation line so it'll try again without exiting if it happened to be that multiple threads try to create a file in the same place at the same time.

```
Exception in thread "main" java.nio.file.FileAlreadyExistsException: /tmp/dependencies-sorter/2023-04-05T21:51:56.445482Z.log
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.createFile(Files.java:648)
	at com.squareup.sort.MainKt.logger(main.kt:33)
	at com.squareup.sort.MainKt.main(main.kt:16)
```

Update: based on review feedback decided to just use `kotlin.io.path.createTempFile` for the logging.