### PR TITLE
Fix path traversal issue + simplify

### DIFF
--- a/app/src/main/kotlin/com/squareup/sort/BuildDotGradleFinder.kt
+++ b/app/src/main/kotlin/com/squareup/sort/BuildDotGradleFinder.kt
@@ -1,15 +1,20 @@
 package com.squareup.sort
 
-import java.nio.file.Files
+import java.io.File
 import java.nio.file.Path
-import java.util.stream.Collectors
 import kotlin.io.path.pathString
-import kotlin.streams.asSequence
 
 class BuildDotGradleFinder(
   private val root: Path,
-  searchPaths: List<String>
+  searchPaths: List<String>,
+  skipHiddenAndBuildDirs: Boolean
 ) {
+
+  private val traversalFilter: (File) -> Boolean = if (skipHiddenAndBuildDirs) {
+    { dir -> !dir.name.startsWith(".") && dir.name != "build" }
+  } else {
+    { true }
+  }
 
   val buildDotGradles: Set<Path> = searchPaths.asSequence()
     // nb, if the path passed to the resolve method is already an absolute path, it returns that.
@@ -18,11 +23,12 @@ class BuildDotGradleFinder(
       if (searchPath.isBuildDotGradle()) {
         sequenceOf(searchPath)
       } else {
-        Files.walk(searchPath).use { paths ->
-          paths.parallel()
-            .filter(Path::isBuildDotGradle)
-            .asSequence()
-        }
+        // Use File.walk() so we have access to the `onEnter` filter.
+        // Can switch to Path.walk() once it's stable and offers the same API.
+        searchPath.toFile().walk()
+          .onEnter(traversalFilter)
+          .map(File::toPath)
+          .filter(Path::isBuildDotGradle)
       }
     }
     .toSet()
@@ -30,8 +36,9 @@ class BuildDotGradleFinder(
   interface Factory {
     fun of(
       root: Path,
-      searchPaths: List<String>
-    ): BuildDotGradleFinder = BuildDotGradleFinder(root, searchPaths)
+      searchPaths: List<String>,
+      skipHiddenAndBuildDirs: Boolean
+    ): BuildDotGradleFinder = BuildDotGradleFinder(root, searchPaths, skipHiddenAndBuildDirs)
   }
 }
 

--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -11,7 +11,6 @@ import com.squareup.sort.Status.SUCCESS
 import com.squareup.sort.Status.UNKNOWN_MODE
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.slf4j.event.Level
 import picocli.CommandLine.Command
 import picocli.CommandLine.HelpCommand
 import picocli.CommandLine.Option
@@ -59,6 +58,15 @@ class SortCommand(
   var quiet: Boolean = false
 
   @Option(
+    names = ["--skip-hidden-and-build-dirs"],
+    description = [
+      "Flag to control whether file tree walking looks in build and hidden directories. True by default."
+    ],
+    defaultValue = "true"
+  )
+  var skipHiddenAndBuildDirs: Boolean = true
+
+  @Option(
     names = ["-m", "--mode"],
     description = [
       "Mode: [sort, check]. Defaults to 'sort'. Check will report if a file is already sorted"
@@ -84,7 +92,11 @@ class SortCommand(
     logger.info("Sorting build.gradle(.kts) scripts in the following paths: ${paths.joinToString()}")
 
     val start = System.currentTimeMillis()
-    val filesToSort = buildFileFinder.of(pwd, paths).buildDotGradles
+    val filesToSort = buildFileFinder.of(
+      root = pwd,
+      searchPaths = paths,
+      skipHiddenAndBuildDirs = skipHiddenAndBuildDirs
+    ).buildDotGradles
     val findFileTime = System.currentTimeMillis()
 
     if (filesToSort.isEmpty()) {


### PR DESCRIPTION
Resolves #44. This simplifies it by skipping parallelism and using purely kotlin APIs. This also adds a new flag to control skipping hidden (i.e. dirs that start with `.`) and `build` dirs to improve speed.