### PR TITLE
Sort add function call in depedencies

### DIFF
--- a/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
+++ b/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
@@ -20,7 +20,7 @@ block
 
 normalDeclaration
     :   configuration PARENS_OPEN? quote? dependency quote? PARENS_CLOSE? closure?
-    |   configuration PARENS_OPEN quote ID quote COMMA dependency PARENS_CLOSE? closure?
+    |   configuration PARENS_OPEN quote? ID quote? COMMA dependency PARENS_CLOSE? closure?
     ;
 
 testFixturesDeclaration

--- a/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
+++ b/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
@@ -20,6 +20,7 @@ block
 
 normalDeclaration
     :   configuration PARENS_OPEN? quote? dependency quote? PARENS_CLOSE? closure?
+    |   configuration PARENS_OPEN quote ID quote COMMA dependency PARENS_CLOSE? closure?
     ;
 
 testFixturesDeclaration

--- a/sort/src/test/groovy/com/squareup/sort/SorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/SorterSpec.groovy
@@ -438,7 +438,7 @@ final class SorterSpec extends Specification {
     )).inOrder()
   }
 
-    def "sort add function call in depedencies"() {
+    def "sort add function call in dependencies"() {
     given:
     def buildScript = dir.resolve('build.gradle')
     Files.writeString(buildScript,
@@ -451,6 +451,7 @@ final class SorterSpec extends Specification {
             api(projects.bar)
 
             add("debugImplementation", projects.foo)
+            add(releaseImplementation, projects.foo)
           }
         '''.stripIndent())
 
@@ -464,6 +465,7 @@ final class SorterSpec extends Specification {
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf('''\
           dependencies {
             add("debugImplementation", projects.foo)
+            add(releaseImplementation, projects.foo)
 
             api(projects.bar)
             api(projects.foo)

--- a/sort/src/test/groovy/com/squareup/sort/SorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/SorterSpec.groovy
@@ -438,6 +438,42 @@ final class SorterSpec extends Specification {
     )).inOrder()
   }
 
+    def "sort add function call in depedencies"() {
+    given:
+    def buildScript = dir.resolve('build.gradle')
+    Files.writeString(buildScript,
+      '''\
+          dependencies {
+            implementation(projects.foo)
+            implementation(projects.bar)
+
+            api(projects.foo)
+            api(projects.bar)
+
+            add("debugImplementation", projects.foo)
+          }
+        '''.stripIndent())
+
+    when:
+    def newScript = Sorter.sorterFor(buildScript).rewritten()
+
+    then:
+    notThrown(BuildScriptParseException)
+
+    and:
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf('''\
+          dependencies {
+            add("debugImplementation", projects.foo)
+
+            api(projects.bar)
+            api(projects.foo)
+
+            implementation(projects.bar)
+            implementation(projects.foo)
+          }
+        '''.stripIndent())).inOrder()
+  }
+
   private static List<String> trimmedLinesOf(CharSequence content) {
     // to lines and trim whitespace off end
     return content.readLines().collect { it.replaceFirst('\\s+\$', '') }


### PR DESCRIPTION
Fixes first part of #57.

This change allows to call `add(configurationName: String, dependencyNotation: Any)` and similar functions.

I am aware this is not a common usecase. 
Please guide change for better solution. 