### PR TITLE
Have badge link to central

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This JVM CLI app and companion Gradle plugin can sort the dependencies of a `bui
 
 #### Apply it
 
-![Maven Central](https://img.shields.io/maven-central/v/com.squareup.sort-dependencies/com.squareup.sort-dependencies.gradle.plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.sort-dependencies/com.squareup.sort-dependencies.gradle.plugin)](https://central.sonatype.com/artifact/com.squareup/sort-dependencies-gradle-plugin/)
 
 ```groovy
 // build.gradle[.kts]


### PR DESCRIPTION
All images are clickable by default but GitHub just opens the image. Instead, send people to the Maven Central page where they can get things historical version information.