### PR TITLE
Flip quiet to verbose

### DIFF
--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -45,13 +45,13 @@ class SortCommand(
 ) : Callable<Int> {
 
   @Option(
-    names = ["-q", "--quiet"],
+    names = ["-v", "--verbose"],
     description = [
-      "Quiet mode. Only print errors. Logs are still written to a log file."
+      "Verbose mode. All logs are printed."
     ],
     defaultValue = "false"
   )
-  var quiet: Boolean = false
+  var verbose: Boolean = false
 
   @Option(
     names = ["--skip-hidden-and-build-dirs"],
@@ -79,7 +79,7 @@ class SortCommand(
 
   override fun call(): Int {
     // Use `use()` to ensure the logger is closed + dumps any close-time diagnostics
-    return logger(quiet).use(::callWithLogger)
+    return logger(!verbose).use(::callWithLogger)
   }
 
   private fun callWithLogger(logger: DelegatingLogger): Int {

--- a/app/src/test/groovy/com/squareup/SortCommandSpec.groovy
+++ b/app/src/test/groovy/com/squareup/SortCommandSpec.groovy
@@ -20,10 +20,10 @@ final class SortCommandSpec extends Specification {
     def commandLine = new CommandLine(newSortCommand())
 
     when:
-    def parseResult = commandLine.parseArgs('-m', 'check', '-q')
+    def parseResult = commandLine.parseArgs('-m', 'check', '-v')
 
     then:
-    parseResult.expandedArgs() == ['-m', 'check', '-q']
+    parseResult.expandedArgs() == ['-m', 'check', '-v']
   }
 
   private SortCommand newSortCommand() {

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -40,10 +40,16 @@ abstract class SortDependenciesTask @Inject constructor(
   @get:Input
   abstract val mode: Property<String>
 
+  @get:Optional
+  @get:Option(option = "verbose", description = "Enables verbose logging.")
+  @get:Input
+  abstract val verbose: Property<Boolean>
+
   @TaskAction
   fun action() {
     val buildScript = buildScript.get().asFile.absolutePath
     val mode = mode.getOrElse("sort")
+    val verbose = verbose.getOrElse(false)
 
     if (mode != "check" && mode != "sort") {
       throw InvalidUserDataException("Mode must be 'sort' or 'check'. Was '$mode'.")
@@ -58,7 +64,9 @@ abstract class SortDependenciesTask @Inject constructor(
         args = listOf(
           buildScript,
           "--mode",
-          mode
+          mode,
+          "--verbose",
+          verbose.toString()
         )
       }
     }

--- a/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
+++ b/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
@@ -81,7 +81,7 @@ final class FunctionalSpec extends Specification {
     Files.writeString(buildScript, BUILD_SCRIPT)
 
     when: 'We sort dependencies'
-    def result = buildAndFail(dir, 'checkSortDependencies')
+    def result = buildAndFail(dir, 'checkSortDependencies', '--verbose')
 
     then: 'Dependencies are not sorted'
     result.output.contains('1 scripts are not ordered correctly.')


### PR DESCRIPTION
Resolves #61. This makes it run in "quiet" mode (i.e. errors only) by default, and you can make it louder with `--verbose`