### PR TITLE
Split Gradle tasks into check and sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ plugins {
 ./gradlew :my:app:sortDependencies
 
 # Identical to the above
-./gradlew :my:app:sortDependencies --mode sort
+./gradlew :my:app:sortDependencies
 ```
 
 #### Check it
 
 ```shell
-./gradlew :my:app:sortDependencies --mode check
+./gradlew :my:app:checkSortDependencies
 ```
+
+This task is automatically added as a dependency to the `check` task.
 
 ## Test it
 

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -3,7 +3,7 @@ package com.squareup.sort
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 @Suppress("unused")
 class SortDependenciesPlugin : Plugin<Project> {
@@ -19,8 +19,8 @@ class SortDependenciesPlugin : Plugin<Project> {
     val checkTask = tasks.register("checkSortDependencies", SortDependenciesTask::class.java) { t ->
       t.configure("check", target)
     }
-    pluginManager.withPlugin("java-base") {
-      target.project.tasks.named(JavaBasePlugin.CHECK_TASK_NAME, Task::class.java).configure {
+    pluginManager.withPlugin("lifecycle-base") {
+      target.project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME, Task::class.java).configure {
         it.dependsOn(checkTask)
       }
     }

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -2,6 +2,8 @@ package com.squareup.sort
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.JavaBasePlugin
 
 @Suppress("unused")
 class SortDependenciesPlugin : Plugin<Project> {
@@ -12,18 +14,28 @@ class SortDependenciesPlugin : Plugin<Project> {
 
   override fun apply(target: Project): Unit = target.run {
     tasks.register("sortDependencies", SortDependenciesTask::class.java) { t ->
-      with(t) {
-        val version = javaClass.classLoader.getResourceAsStream(VERSION_FILENAME)
-          ?.bufferedReader()
-          ?.use { it.readLine() }
-          ?: error("Can't find $VERSION_FILENAME")
-        val coordinates = "com.squareup:sort-gradle-dependencies-app:$version"
-        val app = configurations.detachedConfiguration(dependencies.create(coordinates))
-
-        buildScript.set(buildFile)
-        sortProgram.setFrom(app)
-        mode.convention("sort")
+      t.configure("sort", target)
+    }
+    val checkTask = tasks.register("checkSortDependencies", SortDependenciesTask::class.java) { t ->
+      t.configure("check", target)
+    }
+    pluginManager.withPlugin("java-base") {
+      target.project.tasks.named(JavaBasePlugin.CHECK_TASK_NAME, Task::class.java).configure {
+        it.dependsOn(checkTask)
       }
     }
+  }
+
+  private fun SortDependenciesTask.configure(mode: String, project: Project) {
+      val version = javaClass.classLoader.getResourceAsStream(VERSION_FILENAME)
+        ?.bufferedReader()
+        ?.use { it.readLine() }
+        ?: error("Can't find $VERSION_FILENAME")
+      val coordinates = "com.squareup:sort-gradle-dependencies-app:$version"
+      val app = project.configurations.detachedConfiguration(project.dependencies.create(coordinates))
+
+      buildScript.set(project.buildFile)
+      sortProgram.setFrom(app)
+      this.mode.set(mode)
   }
 }

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -37,8 +37,6 @@ abstract class SortDependenciesTask @Inject constructor(
   @get:InputFiles
   abstract val sortProgram: ConfigurableFileCollection
 
-  @get:Optional
-  @get:Option(option = "mode", description = "The sort mode. May be 'check' or 'sort'.")
   @get:Input
   abstract val mode: Property<String>
 

--- a/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
+++ b/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
@@ -33,12 +33,12 @@ final class FunctionalSpec extends Specification {
         id 'java-library'
         id 'com.squareup.sort-dependencies'
       }
-      
+
       repositories {
         mavenCentral()
         maven { url '$REPO' }
       }
-      
+
       dependencies {
         implementation(platform('com.squareup.okhttp3:okhttp-bom:4.10.0'))
         implementation('com.squareup.okhttp3:okhttp:4.10.0')
@@ -81,7 +81,7 @@ final class FunctionalSpec extends Specification {
     Files.writeString(buildScript, BUILD_SCRIPT)
 
     when: 'We sort dependencies'
-    def result = buildAndFail(dir, 'sortDependencies', '--mode', 'check')
+    def result = buildAndFail(dir, 'checkSortDependencies')
 
     then: 'Dependencies are not sorted'
     result.output.contains('1 scripts are not ordered correctly.')
@@ -92,12 +92,12 @@ final class FunctionalSpec extends Specification {
       id 'java-library'
       id 'com.squareup.sort-dependencies'
     }
-    
+
     repositories {
       mavenCentral()
       maven { url '$REPO' }
     }
-    
+
     dependencies {
       implementation('com.squareup.okio:okio:3.2.0')
       implementation('com.squareup.okhttp3:okhttp:4.10.0')
@@ -110,12 +110,12 @@ final class FunctionalSpec extends Specification {
       `java-library`
       id("com.squareup.sort-dependencies")
     }
-    
+
     repositories {
       mavenCentral()
       maven { url = uri("$REPO") }
     }
-    
+
     dependencies {
       implementation("com.squareup.okio:okio:3.2.0")
       implementation("com.squareup.okhttp3:okhttp:4.10.0")


### PR DESCRIPTION
Resolves #60. This splits the gradle work into two tasks - one that runs the sorting and the other that checks it. This also wires the latter into the java-base `check` task.

CC @JakeWharton 