### PR TITLE
Move 'text' earlier in the grammar. For some reasons this fixes the tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # gradle-dependencies-sorter
 
 ## Version 0.3
-
 * Replace `--quiet` with `--verbose` flag. The CLI and gradle plugin now run in quiet mode by default, and can be made verbose with `--verbose`.
 * Split Gradle tasks into `sortDependencies` (which sorts) and `checkSortDependencies` (which checks that dependencies are sorted). The latter is automatically added as a dependency of the `check` lifecycle task too.
 * New: Support `add(configuration, dependency)` notation. Thanks to [@kozaxinan](https://github.com/kozaxinan) for the contribution.

--- a/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
+++ b/grammar/src/main/antlr/com/squareup/grammar/GradleGroovyScript.g4
@@ -3,7 +3,7 @@ parser grammar GradleGroovyScript;
 options { tokenVocab=GradleGroovyScriptLexer; }
 
 script
-    :   (dependencies|buildscript|text)* EOF
+    :   (text|dependencies|buildscript)* EOF
     ;
 
 dependencies

--- a/grammar/src/test/groovy/com/squareup/grammar/SimpleANTLRErrorListener.groovy
+++ b/grammar/src/test/groovy/com/squareup/grammar/SimpleANTLRErrorListener.groovy
@@ -12,7 +12,7 @@ final class SimpleANTLRErrorListener implements ANTLRErrorListener {
   private Closure<RuntimeException> onError
 
   SimpleANTLRErrorListener(Closure<RuntimeException> onError) {
-    this.onError = onError;
+    this.onError = onError
   }
 
   @Override


### PR DESCRIPTION
```
./gradlew check
```
now succeeds locally.