### PR TITLE
Fix verbose flag in SortDependenciesTask

### DIFF
--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -63,7 +63,8 @@ abstract class SortDependenciesTask @Inject constructor(
         classpath = sortProgram
         args = buildList {
           add(buildScript)
-          addAll("--mode", mode)
+          add("--mode")
+          add(mode)
           if (verbose) {
             add("--verbose")
           }

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -66,7 +66,7 @@ abstract class SortDependenciesTask @Inject constructor(
           addAll("--mode", mode)
           if (verbose) {
             add("--verbose")
-          )
+          }
         }
       }
     }

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -61,13 +61,13 @@ abstract class SortDependenciesTask @Inject constructor(
       with(javaExecSpec) {
         mainClass.set("com.squareup.sort.MainKt")
         classpath = sortProgram
-        args = listOf(
-          buildScript,
-          "--mode",
-          mode,
-          "--verbose",
-          verbose.toString()
-        )
+        args = buildList {
+          add(buildScript)
+          addAll("--mode", mode)
+          if (verbose) {
+            add("--verbose")
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
This treated it like an assignable argument when it's actually a flag, so the task always ran verbosely