### PR TITLE
Adds the gradle.properties VERSION to jar artifacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,3 +74,7 @@ def javaComponent = components['java'] as AdhocComponentWithVariants
     skip()
   }
 }
+
+processResources {
+  expand(Map.of("VERSION", providers.gradleProperty("VERSION").get()))
+}

--- a/app/src/main/kotlin/com/squareup/sort/ResourceVersionProvider.kt
+++ b/app/src/main/kotlin/com/squareup/sort/ResourceVersionProvider.kt
@@ -1,0 +1,21 @@
+package com.squareup.sort
+
+import picocli.CommandLine.IVersionProvider
+import java.util.Properties
+
+class ResourceVersionProvider : IVersionProvider {
+  override fun getVersion(): Array<String> {
+    return arrayOf(getVersionFromResource())
+  }
+
+  private fun getVersionFromResource(): String {
+    val url = javaClass.getResource("/appinfo.properties")
+    val properties = Properties()
+    return if (url != null) {
+      properties.load(url.openStream())
+      properties.getProperty("app.version")
+    } else {
+      "No appinfo.properties file found in the classpath."
+    }
+  }
+}

--- a/app/src/main/kotlin/com/squareup/sort/ResourceVersionProvider.kt
+++ b/app/src/main/kotlin/com/squareup/sort/ResourceVersionProvider.kt
@@ -10,8 +10,8 @@ class ResourceVersionProvider : IVersionProvider {
 
   private fun getVersionFromResource(): String {
     val url = javaClass.getResource("/appinfo.properties")
-    val properties = Properties()
     return if (url != null) {
+      val properties = Properties()
       properties.load(url.openStream())
       properties.getProperty("app.version")
     } else {

--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -33,7 +33,7 @@ import kotlin.io.path.writeText
 @Command(
   name = "sort",
   mixinStandardHelpOptions = true,
-  version = ["0.1"],
+  versionProvider = ResourceVersionProvider::class,
   description = ["Sorts dependencies"],
   subcommands = [
     HelpCommand::class

--- a/app/src/main/kotlin/com/squareup/sort/main.kt
+++ b/app/src/main/kotlin/com/squareup/sort/main.kt
@@ -4,7 +4,17 @@ import picocli.CommandLine
 import kotlin.system.exitProcess
 
 fun main(vararg args: String) {
+  println("Version=${getVersionFromResources()}")
   val cli = CommandLine(SortCommand())
   val exitCode = cli.execute(*args)
   exitProcess(exitCode)
+}
+
+fun getVersionFromResources(): String? {
+  val versionKeyValue = (Any::class as Any).javaClass.getResourceAsStream("/appinfo.properties")
+    ?.bufferedReader()
+    ?.readLines()
+    ?.first()
+
+  return versionKeyValue?.substringAfter("=")
 }

--- a/app/src/main/kotlin/com/squareup/sort/main.kt
+++ b/app/src/main/kotlin/com/squareup/sort/main.kt
@@ -4,17 +4,7 @@ import picocli.CommandLine
 import kotlin.system.exitProcess
 
 fun main(vararg args: String) {
-  println("Version=${getVersionFromResources()}")
   val cli = CommandLine(SortCommand())
   val exitCode = cli.execute(*args)
   exitProcess(exitCode)
-}
-
-fun getVersionFromResources(): String? {
-  val versionKeyValue = (Any::class as Any).javaClass.getResourceAsStream("/appinfo.properties")
-    ?.bufferedReader()
-    ?.readLines()
-    ?.first()
-
-  return versionKeyValue?.substringAfter("=")
 }

--- a/app/src/main/resources/appinfo.properties
+++ b/app/src/main/resources/appinfo.properties
@@ -1,0 +1,1 @@
+app.version=${VERSION}


### PR DESCRIPTION
### Description
- I noticed running the version command `-V` for the jar always returns the [hardcoded](https://github.com/square/gradle-dependencies-sorter/blob/main/app/src/main/kotlin/com/squareup/sort/SortCommand.kt#L36) `0.1`
- This PR adds support for expanding the `VERSION` property into a resource file that gets distributed with the jar, and provides the version to the `SortCommand` at runtime.
- [PicoCLI Version Provider Documentation](https://picocli.info/#_command_versionprovider_attribute)