### PR TITLE
Prepare for release 0.7.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual run'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'square/gradle-dependencies-sorter' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Run tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check -s
+
+      - name: Publish artifacts
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenCentral -s
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-dependencies-sorter
 
+## Version 0.7
+* [Fix] Fix verbose flag in SortDependenciesTask.
+* [Chore] Switch to Clikt CLI.
+
 ## Version 0.6
 * [New] make `check` task dependency optional (but on by default).
   ```sortDependencies { check(<true|false>) }```

--- a/build-logic/src/main/kotlin/nexus/Credentials.kt
+++ b/build-logic/src/main/kotlin/nexus/Credentials.kt
@@ -15,7 +15,7 @@ open class Credentials @Inject constructor(private val project: Project) {
   }
 
   companion object {
-    private const val USERNAME = "sonatypeUsername"
-    private const val PASSWORD = "sonatypePassword"
+    private const val USERNAME = "mavenCentralUsername"
+    private const val PASSWORD = "mavenCentralPassword"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.caching=true
 org.gradle.parallel=true
 
 GROUP=com.squareup
-VERSION=0.7-SNAPSHOT
+VERSION=0.7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 antlr = "4.10.1"
-dagp = "1.20.0"
+dagp = "1.30.0"
 java = "11"
 junit5 = "5.7.2"
-kotlin = "1.8.10"
+kotlin = "1.9.22"
 moshi = "1.14.0"
 retrofit = "2.9.0"
 shadow = "8.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With inspiration from https://github.com/square/okhttp/blob/master/.github/workflows/build.yml#L17-L44.

Square now requires releases to be published from Github Actions. I think/hope this is configured correctly.