### PR TITLE
Add flag to disable blank lines between configurations

### DIFF
--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesExtension.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesExtension.kt
@@ -28,6 +28,14 @@ abstract class SortDependenciesExtension @Inject constructor(
         ?: error("Can't find '$VERSION_FILENAME'")
     )
 
+  /**
+   * When true, a blank line will be inserted between dependencies of different configurations
+   * (`api`, `implementation`, etc.). Enabled by default.
+   */
+  val insertBlankLines: Property<Boolean> = objects
+    .property(Boolean::class.java)
+    .convention(true)
+
   internal val check: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   fun check(shouldCheck: Boolean) {

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -27,10 +27,10 @@ class SortDependenciesPlugin : Plugin<Project> {
     }
 
     tasks.register("sortDependencies", SortDependenciesTask::class.java) { t ->
-      t.configure("sort", target, sortApp)
+      t.configure("sort", target, sortApp, extension)
     }
     val checkTask = tasks.register("checkSortDependencies", SortDependenciesTask::class.java) { t ->
-      t.configure("check", target, sortApp)
+      t.configure("check", target, sortApp, extension)
     }
 
     afterEvaluate {
@@ -48,11 +48,13 @@ class SortDependenciesPlugin : Plugin<Project> {
   private fun SortDependenciesTask.configure(
     mode: String,
     project: Project,
-    sortApp: Configuration
+    sortApp: Configuration,
+    extension: SortDependenciesExtension,
   ) {
     buildScript.set(project.buildFile)
     sortProgram.setFrom(sortApp)
     version.set(extension.version)
     this.mode.set(mode)
+    insertBlankLines.set(extension.insertBlankLines)
   }
 }

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -49,10 +49,15 @@ abstract class SortDependenciesTask @Inject constructor(
   @get:Input
   abstract val verbose: Property<Boolean>
 
+  @get:Optional
+  @get:Input
+  abstract val insertBlankLines: Property<Boolean>
+
   @TaskAction fun action() {
     val buildScript = buildScript.get().asFile.absolutePath
     val mode = mode.getOrElse("sort")
     val verbose = verbose.getOrElse(false)
+    val insertBlankLines = insertBlankLines.getOrElse(true)
 
     if (mode != "check" && mode != "sort") {
       throw InvalidUserDataException("Mode must be 'sort' or 'check'. Was '$mode'.")
@@ -81,6 +86,10 @@ abstract class SortDependenciesTask @Inject constructor(
             } else {
               add("--verbose")
             }
+          }
+
+          if (!insertBlankLines) {
+            add("--no-blank-lines")
           }
         }
       }

--- a/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
+++ b/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
@@ -229,6 +229,116 @@ final class FunctionalSpec extends Specification {
     build(dir, 'sortDependencies', '--verbose')
   }
 
+  def "no blank lines between different configurations when flag is disabled"() {
+    given: 'A build script with unsorted dependencies and multiple configurations'
+    def buildScript = dir.resolve('build.gradle.kts')
+    Files.writeString(buildScript,
+      """\
+        plugins {
+          `java-library`
+          id("com.squareup.sort-dependencies")
+        }
+
+        sortDependencies {
+          insertBlankLines = false
+        }
+
+        repositories {
+          mavenCentral()
+          maven { url = uri("$REPO") }
+        }
+
+        dependencies {
+          implementation("com.squareup.okio:okio:3.2.0")
+          api("com.squareup.okhttp3:okhttp:4.10.0")
+          testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+        }
+      """.stripIndent()
+    )
+
+    when: 'We sort dependencies in the build folder'
+    build(dir, 'sortDependencies')
+
+    then: 'The build script is sorted with no blank lines between api and implementation'
+    buildScript.text == """\
+      plugins {
+        `java-library`
+        id("com.squareup.sort-dependencies")
+      }
+
+      sortDependencies {
+        insertBlankLines = false
+      }
+
+      repositories {
+        mavenCentral()
+        maven { url = uri("$REPO") }
+      }
+
+      dependencies {
+        api("com.squareup.okhttp3:okhttp:4.10.0")
+        implementation("com.squareup.okio:okio:3.2.0")
+        testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+      }
+    """.stripIndent()
+  }
+
+  def "insert blank lines between different configurations when flag is enabled"() {
+    given: 'A build script with unsorted dependencies and multiple configurations'
+    def buildScript = dir.resolve('build.gradle.kts')
+    Files.writeString(buildScript,
+      """\
+        plugins {
+          `java-library`
+          id("com.squareup.sort-dependencies")
+        }
+
+        sortDependencies {
+          insertBlankLines = true
+        }
+
+        repositories {
+          mavenCentral()
+          maven { url = uri("$REPO") }
+        }
+
+        dependencies {
+          implementation("com.squareup.okio:okio:3.2.0")
+          api("com.squareup.okhttp3:okhttp:4.10.0")
+          testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+        }
+      """.stripIndent()
+    )
+
+    when: 'We sort dependencies in the build folder'
+    build(dir, 'sortDependencies')
+
+    then: 'The build script is sorted with a blank line between api and implementation'
+    buildScript.text == """\
+      plugins {
+        `java-library`
+        id("com.squareup.sort-dependencies")
+      }
+
+      sortDependencies {
+        insertBlankLines = true
+      }
+
+      repositories {
+        mavenCentral()
+        maven { url = uri("$REPO") }
+      }
+
+      dependencies {
+        api("com.squareup.okhttp3:okhttp:4.10.0")
+
+        implementation("com.squareup.okio:okio:3.2.0")
+
+        testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+      }
+    """.stripIndent()
+  }
+
   private static final BUILD_SCRIPT = """\
     plugins {
       id 'java-library'

--- a/sort/src/main/kotlin/com/squareup/sort/Sorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/Sorter.kt
@@ -7,17 +7,28 @@ import java.nio.file.Path
 import kotlin.io.path.pathString
 
 public interface Sorter {
-
   public fun rewritten(): String
   public fun isSorted(): Boolean
   public fun hasParseErrors(): Boolean
   public fun getParseError(): BuildScriptParseException?
 
+  public data class Config(
+    public val insertBlankLines: Boolean,
+  )
+
   public companion object {
-    public fun of(file: Path): Sorter = if (file.pathString.endsWith(".gradle")) {
-      GroovySorter.of(file)
+    public fun defaultConfig(): Config = Config(
+      insertBlankLines = true,
+    )
+
+    @JvmOverloads
+    public fun of(
+      file: Path,
+      config: Config = defaultConfig(),
+    ): Sorter = if (file.pathString.endsWith(".gradle")) {
+      GroovySorter.of(file, config)
     } else if (file.pathString.endsWith(".gradle.kts")) {
-      KotlinSorter.of(file)
+      KotlinSorter.of(file, config)
     } else {
       error("Expected '.gradle' or '.gradle.kts' extension. Was ${file.pathString}")
     }

--- a/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
@@ -18,12 +18,12 @@ import org.antlr.v4.runtime.CharStream
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.TokenStreamRewriter
 import java.nio.file.Path
-import kotlin.io.path.absolutePathString
 
 public class KotlinSorter private constructor(
   private val input: CharStream,
   private val tokens: CommonTokenStream,
   private val errorListener: CollectingErrorListener,
+  private val config: Sorter.Config,
 ) : Sorter, KotlinParserBaseListener() {
 
   private val rewriter = TokenStreamRewriter(tokens)
@@ -134,7 +134,8 @@ public class KotlinSorter private constructor(
     // declarations
     mutableDependencies.declarations().sortedWith(KotlinConfigurationComparator)
       .forEachIndexed { i, entry ->
-        if (i != 0) appendLine()
+        // Place a blank line between chunks of the same configuration, if configured
+        if (i != 0 && config.insertBlankLines) appendLine()
 
         entry.value.sortedWith(dependencyComparator)
           .map { dependency ->
@@ -165,7 +166,8 @@ public class KotlinSorter private constructor(
 
   public companion object {
     @JvmStatic
-    public fun of(file: Path): KotlinSorter {
+    @JvmOverloads
+    public fun of(file: Path, config: Sorter.Config = Sorter.defaultConfig()): KotlinSorter {
       val errorListener = CollectingErrorListener()
 
       return Parser(
@@ -177,6 +179,7 @@ public class KotlinSorter private constructor(
             input = input,
             tokens = tokens,
             errorListener = errorListener,
+            config = config,
           )
         }
       ).listener()

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -502,6 +502,42 @@ final class GroovySorterSpec extends Specification {
     )).inOrder()
   }
 
+  def "sort without inserting newlines between different configurations"() {
+    given:
+    def buildScript = dir.resolve('build.gradle')
+    Files.writeString(buildScript,
+      '''\
+          dependencies {
+            implementation(projects.foo)
+            implementation(projects.bar)
+            implementation(projects.foo)
+
+            api(projects.foo)
+            api(projects.bar)
+            api(projects.foo)
+          }
+        '''.stripIndent())
+
+    when:
+    def config = new Sorter.Config(false)
+    def newScript = GroovySorter.of(buildScript, config).rewritten()
+
+    then:
+    notThrown(BuildScriptParseException)
+
+    and:
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+          dependencies {
+            api(projects.bar)
+            api(projects.foo)
+            implementation(projects.bar)
+            implementation(projects.foo)
+          }
+        '''.stripIndent()
+    )).inOrder()
+  }
+
   def "sort add function call in dependencies"() {
     given:
     def buildScript = dir.resolve('build.gradle')


### PR DESCRIPTION
Basically, this adds a flag to the CLI tool and the Gradle plugin to disable auto-insertion of blank lines between blocks of different configurations. So currently it will generate something like:

```kotlin
dependencies {
  api(libs.a)
  api(libs.b)

  implementation(libs.c)

  testImplementation(libs.d)
  testImplementation(libs.e)
}
```

When this flag is set to false, you get:

```kotlin
dependencies {
  api(libs.a)
  api(libs.b)
  implementation(libs.c)
  testImplementation(libs.d)
  testImplementation(libs.e)
}
```

as in the test cases. Yes I realise this is petty - I just prefer it without blank lines :slightly_smiling_face:

I'm not 100% sure on the double-negativity of the CLI flag - any feedback/suggestions on that is welcome.