### PR TITLE
Add support for different line feed characters

### DIFF
--- a/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
@@ -32,6 +32,7 @@ public class GroovySorter private constructor(
   private val rewriter: TokenStreamRewriter,
   private val errorListener: RewriterErrorListener,
   private val filePath: String,
+  private val lineSeparator: String,
 ) : Sorter, GradleScriptBaseListener() {
 
   // We use a default of two spaces, but update it at most once later on.
@@ -136,7 +137,7 @@ public class GroovySorter private constructor(
 
   override fun exitDependencies(ctx: DependenciesContext) {
     if (isInBuildScriptBlock) return
-    rewriter.replace(ctx.start, ctx.stop, dependenciesBlock())
+    rewriter.replace(ctx.start, ctx.stop, dependenciesBlock().replace("\n", lineSeparator))
 
     // Whenever we exit a dependencies block, clear this map. Each block will be treated separately.
     dependenciesByConfiguration.clear()
@@ -161,10 +162,10 @@ public class GroovySorter private constructor(
             newOrder += declaration
 
             // Write preceding comments if there are any
-            if (texts.comment != null) appendLine(texts.comment)
+            if (texts.comment != null) appendLine(texts.comment.replace("\r", ""))
 
-            append(indent)
-            appendLine(texts.declarationText)
+            append(indent.replace("\r", ""))
+            appendLine(texts.declarationText.replace("\r", ""))
           }
       }
     append("}")
@@ -185,6 +186,10 @@ public class GroovySorter private constructor(
   public companion object {
     @JvmStatic
     public fun of(file: Path): GroovySorter {
+      return of(file, System.lineSeparator())
+    }
+    @JvmStatic
+    public fun of(file: Path, lineSeparator: String): GroovySorter {
       val input = Files.newInputStream(file, StandardOpenOption.READ).use {
         CharStreams.fromStream(it)
       }
@@ -205,7 +210,8 @@ public class GroovySorter private constructor(
         tokens = tokens,
         rewriter = TokenStreamRewriter(tokens),
         errorListener = errorListener,
-        filePath = file.absolutePathString()
+        filePath = file.absolutePathString(),
+        lineSeparator = lineSeparator,
       )
       val tree = parser.script()
       walker.walk(listener, tree)

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -67,7 +67,7 @@ final class GroovySorterSpec extends Specification {
           println 'hello, world'
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
-    def sorter = GroovySorter.of(buildScript)
+    def sorter = GroovySorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -151,7 +151,7 @@ final class GroovySorterSpec extends Specification {
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
-    def sorter = GroovySorter.of(buildScript)
+    def sorter = GroovySorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -196,7 +196,7 @@ final class GroovySorterSpec extends Specification {
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
-    def sorter = GroovySorter.of(buildScript)
+    def sorter = GroovySorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -249,7 +249,7 @@ final class GroovySorterSpec extends Specification {
     Files.writeString(buildScript, fileContent)
 
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -337,7 +337,7 @@ final class GroovySorterSpec extends Specification {
         }
       ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
-    def sorter = GroovySorter.of(buildScript)
+    def sorter = GroovySorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -407,7 +407,7 @@ final class GroovySorterSpec extends Specification {
     Files.writeString(buildScript, fileContent)
 
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -453,7 +453,7 @@ final class GroovySorterSpec extends Specification {
     Files.writeString(buildScript, fileContent)
 
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -500,7 +500,7 @@ final class GroovySorterSpec extends Specification {
     Files.writeString(buildScript, fileContent)
 
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -545,7 +545,7 @@ final class GroovySorterSpec extends Specification {
       ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -629,7 +629,7 @@ final class GroovySorterSpec extends Specification {
     Files.writeString(buildScript, fileContent)
 
     when:
-    def newScript = GroovySorter.of(buildScript).rewritten()
+    def newScript = GroovySorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     extractLineSeparators(newScript).every { it == lineSeparator }

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -8,6 +8,8 @@ import spock.lang.TempDir
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 import static com.google.common.truth.Truth.assertThat
 
@@ -19,8 +21,7 @@ class KotlinSorterSpec extends Specification {
   def "can sort build script"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContent = normalize('''\
           import foo
           import static bar;
 
@@ -64,10 +65,13 @@ class KotlinSorterSpec extends Specification {
           }
 
           println("hello, world")
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
+
     def sorter = KotlinSorter.of(buildScript)
 
     expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           import foo
@@ -113,13 +117,17 @@ class KotlinSorterSpec extends Specification {
           println("hello, world")
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "can sort build script with four-space tabs"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContent = normalize('''\
           dependencies {
               implementation("heart:of-gold:1.0")
               api(project(":marvin"))
@@ -142,10 +150,12 @@ class KotlinSorterSpec extends Specification {
               implementation(project(":milliways"))
               api("zzz:yyy:1.0")
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
     def sorter = KotlinSorter.of(buildScript)
 
     expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
@@ -170,21 +180,27 @@ class KotlinSorterSpec extends Specification {
           }
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "colons have higher precedence than hyphen"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           dependencies {
             api(project(":marvin-robot:so-sad"))
             api(project(":marvin:robot:so-sad"))
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
     def sorter = KotlinSorter.of(buildScript)
 
     expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
@@ -193,6 +209,11 @@ class KotlinSorterSpec extends Specification {
           }
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   // We have observed that, given the start "dependencies{" (no space), and a project dependency, the
@@ -201,13 +222,13 @@ class KotlinSorterSpec extends Specification {
   def "can sort a dependencies{ block"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           dependencies{
             api(project(":nu-metal"))
             api(project(":magic"))
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
 
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
@@ -216,6 +237,7 @@ class KotlinSorterSpec extends Specification {
     notThrown(BuildScriptParseException)
 
     and:
+    extractLineSeparators(newScript).every { it == lineSeparator }
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
@@ -224,13 +246,17 @@ class KotlinSorterSpec extends Specification {
           }
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "will not sort already sorted build script"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           import foo
           import static bar;
 
@@ -267,7 +293,8 @@ class KotlinSorterSpec extends Specification {
           }
 
           println("hello, world")
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
     def sorter = KotlinSorter.of(buildScript)
 
     when:
@@ -275,13 +302,17 @@ class KotlinSorterSpec extends Specification {
 
     then:
     thrown(AlreadyOrderedException)
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "sort can handle 'path:' notation"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
         dependencies {
           api(project(":path:path"))
           api(project(":zaphod"))
@@ -292,10 +323,12 @@ class KotlinSorterSpec extends Specification {
           api(project(path = ":trillian"))
           api(project(":eddie:eddie"))
         }
-      '''.stripIndent())
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
     def sorter = KotlinSorter.of(buildScript)
 
     expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
         dependencies {
@@ -309,22 +342,28 @@ class KotlinSorterSpec extends Specification {
         }
       '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "sort can handle 'files'-like notation"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
         dependencies {
           implementation(files("a.jar"))
           api(file("another.jar"))
           compileOnly(fileTree("libs") { include("*.jar") })
         }
-      '''.stripIndent())
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
     def sorter = KotlinSorter.of(buildScript)
 
     expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
         dependencies {
@@ -336,6 +375,11 @@ class KotlinSorterSpec extends Specification {
         }
       '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "a script without dependencies is already sorted"() {
@@ -370,8 +414,7 @@ class KotlinSorterSpec extends Specification {
   def "dedupe identical dependencies"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           dependencies {
             implementation(projects.foo)
             implementation(projects.bar)
@@ -381,7 +424,8 @@ class KotlinSorterSpec extends Specification {
             api(projects.bar)
             api(projects.foo)
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
 
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
@@ -390,6 +434,7 @@ class KotlinSorterSpec extends Specification {
     notThrown(BuildScriptParseException)
 
     and:
+    extractLineSeparators(newScript).every { it == lineSeparator }
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
@@ -401,13 +446,17 @@ class KotlinSorterSpec extends Specification {
           }
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "keep identical dependencies that have non-identical comments"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           dependencies {
             // Foo implementation
             implementation(projects.foo)
@@ -421,7 +470,8 @@ class KotlinSorterSpec extends Specification {
             // Foo api 2nd
             api(projects.foo)
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
 
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
@@ -430,6 +480,7 @@ class KotlinSorterSpec extends Specification {
     notThrown(BuildScriptParseException)
 
     and:
+    extractLineSeparators(newScript).every { it == lineSeparator }
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
@@ -445,13 +496,17 @@ class KotlinSorterSpec extends Specification {
           }
         '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "sort add function call in dependencies"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
           dependencies {
             implementation(projects.foo)
             implementation(projects.bar)
@@ -462,7 +517,8 @@ class KotlinSorterSpec extends Specification {
             add("debugImplementation", projects.foo)
             add(releaseImplementation, projects.foo)
           }
-        '''.stripIndent())
+        ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
 
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
@@ -471,6 +527,7 @@ class KotlinSorterSpec extends Specification {
     notThrown(BuildScriptParseException)
 
     and:
+    extractLineSeparators(newScript).every { it == lineSeparator }
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf('''\
           dependencies {
             add("debugImplementation", projects.foo)
@@ -483,13 +540,17 @@ class KotlinSorterSpec extends Specification {
             implementation(projects.foo)
           }
         '''.stripIndent())).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   def "can sort dependencies with artifact type specified"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      '''\
+    def fileContents = normalize('''\
         dependencies {
           implementation(projects.foo.internal)
           implementation(projects.bar.public)
@@ -502,7 +563,8 @@ class KotlinSorterSpec extends Specification {
           implementation(libs.common.view)
           implementation(projects.core)
         }
-      '''.stripIndent())
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
 
@@ -510,6 +572,7 @@ class KotlinSorterSpec extends Specification {
     notThrown(BuildScriptParseException)
 
     and:
+    extractLineSeparators(newScript).every { it == lineSeparator }
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       '''\
         dependencies {
@@ -526,14 +589,18 @@ class KotlinSorterSpec extends Specification {
         }
       '''.stripIndent()
     )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   // https://github.com/square/gradle-dependencies-sorter/issues/59
   def "can sort multiple semantically different dependencies blocks"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
-    Files.writeString(buildScript,
-      """\
+    def fileContents = normalize("""\
       import app.cash.redwood.buildsupport.FlexboxHelpers
 
       apply(plugin = "com.android.library")
@@ -579,14 +646,15 @@ class KotlinSorterSpec extends Specification {
 
       android {
         namespace = "app.cash.redwood.layout.composeui"
-      }""".stripIndent()
-    )
+      }""", lineSeparator)
+    Files.writeString(buildScript, fileContents)
 
     when:
     def newScript = KotlinSorter.of(buildScript).rewritten()
 
     then:
-    assertThat(newScript).isEqualTo(
+    extractLineSeparators(newScript).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       """\
       import app.cash.redwood.buildsupport.FlexboxHelpers
 
@@ -635,11 +703,29 @@ class KotlinSorterSpec extends Specification {
       android {
         namespace = "app.cash.redwood.layout.composeui"
       }""".stripIndent()
-    )
+    )).inOrder()
+
+    where:
+    lineSeparator|_
+    '\n'|_
+    '\r\n'|_
   }
 
   private static List<String> trimmedLinesOf(CharSequence content) {
     // to lines and trim whitespace off end
     return content.readLines().collect { it.replaceFirst('\\s+\$', '') }
+  }
+
+  private static CharSequence normalize(CharSequence input, String lineSeparator) {
+    return input.stripIndent().replace('\n', lineSeparator)
+  }
+
+  private static List<String> extractLineSeparators(CharSequence input) {
+    List<String> lineSeparators = new ArrayList<>()
+    Matcher matcher = Pattern.compile("(\\r\\n|\\r|\\n)").matcher(input)
+    while (matcher.find()) {
+      lineSeparators.add(matcher.group())
+    }
+    return lineSeparators
   }
 }

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -68,7 +68,7 @@ class KotlinSorterSpec extends Specification {
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
 
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -152,7 +152,7 @@ class KotlinSorterSpec extends Specification {
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -197,7 +197,7 @@ class KotlinSorterSpec extends Specification {
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -231,7 +231,7 @@ class KotlinSorterSpec extends Specification {
     Files.writeString(buildScript, fileContents)
 
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -295,7 +295,7 @@ class KotlinSorterSpec extends Specification {
           println("hello, world")
         ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     when:
     sorter.rewritten()
@@ -325,7 +325,7 @@ class KotlinSorterSpec extends Specification {
         }
       ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -360,7 +360,7 @@ class KotlinSorterSpec extends Specification {
         }
       ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
-    def sorter = KotlinSorter.of(buildScript)
+    def sorter = KotlinSorter.of(buildScript, lineSeparator)
 
     expect:
     extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
@@ -428,7 +428,7 @@ class KotlinSorterSpec extends Specification {
     Files.writeString(buildScript, fileContents)
 
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -474,7 +474,7 @@ class KotlinSorterSpec extends Specification {
     Files.writeString(buildScript, fileContents)
 
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -521,7 +521,7 @@ class KotlinSorterSpec extends Specification {
     Files.writeString(buildScript, fileContents)
 
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -566,7 +566,7 @@ class KotlinSorterSpec extends Specification {
       ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     notThrown(BuildScriptParseException)
@@ -650,7 +650,7 @@ class KotlinSorterSpec extends Specification {
     Files.writeString(buildScript, fileContents)
 
     when:
-    def newScript = KotlinSorter.of(buildScript).rewritten()
+    def newScript = KotlinSorter.of(buildScript, lineSeparator).rewritten()
 
     then:
     extractLineSeparators(newScript).every { it == lineSeparator }


### PR DESCRIPTION
* Adjust tests so that they detect inconsistencies in line separators
* Extend sorter to work with any line separator characters

Fixes #106.

I'm not sure if this is particularly ugly (the \r replacement) but I'm open to other suggestions.