### PR TITLE
fix: suggest fix action based on invocation context.

### DIFF
--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -12,8 +12,11 @@ class SortDependenciesPlugin : Plugin<Project> {
     const val VERSION_FILENAME = "com-squareup-sort-version.txt"
   }
 
+  private lateinit var extension: SortDependenciesExtension
+
   override fun apply(target: Project): Unit = target.run {
-    val extension = SortDependenciesExtension.create(this)
+    extension = SortDependenciesExtension.create(this)
+
     // nb: Can't use a detached configuration because that needs a Dependency, not a dependency notation. The latter can
     // be lazily evaluated (as below) while the former needs to (e.g.) know its version eagerly: it is more constrained.
     val sortApp = configurations.maybeCreate("sortDependencies").apply {
@@ -49,6 +52,7 @@ class SortDependenciesPlugin : Plugin<Project> {
   ) {
     buildScript.set(project.buildFile)
     sortProgram.setFrom(sortApp)
+    version.set(extension.version)
     this.mode.set(mode)
   }
 }

--- a/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
+++ b/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
@@ -122,6 +122,11 @@ final class FunctionalSpec extends Specification {
 
     then: 'Dependencies are not sorted'
     result.output.contains('1 scripts are not ordered correctly.')
+    result.output.contains(
+      '''\
+      Fix by running
+      ./gradlew sortDependencies'''.stripIndent()
+    )
   }
 
   def "checks sort order when executing 'check' task"() {


### PR DESCRIPTION
Gradle or CLI.

Resolves https://github.com/square/gradle-dependencies-sorter/issues/89.