### PR TITLE
fix: emit errors even when not in verbose mode.

### DIFF
--- a/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
+++ b/app/src/main/kotlin/com/squareup/sort/SortCommand.kt
@@ -122,10 +122,10 @@ class SortCommand(
         logger.trace("Successfully sorted: ${file.pathString} ")
         successCount++
       } catch (e: BuildScriptParseException) {
-        logger.warn("Parsing error: ${file.pathString} \n${e.localizedMessage}")
+        logger.error("Parsing error: ${file.pathString} \n${e.localizedMessage}")
         parseErrorCount++
       } catch (e: IllegalStateException) {
-        logger.warn("Parsing error: ${file.pathString} \n${e.localizedMessage}")
+        logger.error("Parsing error: ${file.pathString} \n${e.localizedMessage}")
         parseErrorCount++
       } catch (_: AlreadyOrderedException) {
         logger.trace("Already ordered: ${file.pathString} ")
@@ -170,11 +170,11 @@ class SortCommand(
         }
         if (sorter.hasParseErrors()) {
           val error = checkNotNull(sorter.getParseError()) { "There must be a parse error." }
-          logger.trace("Parsing error: ${file.pathString} \n${error.localizedMessage}")
+          logger.error("Parsing error: ${file.pathString} \n${error.localizedMessage}")
           parseErrorCount++
         }
       } catch (t: Throwable) {
-        logger.trace("Parsing error: ${file.pathString}")
+        logger.error("Parsing error: ${file.pathString}")
         parseErrorCount++
       }
     }


### PR DESCRIPTION
It was supposed to do this, but we stopped calling logger.error(), which is what would trigger that behavior.

Resolves https://github.com/square/gradle-dependencies-sorter/issues/122

As a follow-up, consider adding a verbose property to the extension.