### PR TITLE
chore: remove unused entries from version catalog.

### DIFF
--- a/build-logic/src/main/kotlin/com/squareup/convention/AppConvention.kt
+++ b/build-logic/src/main/kotlin/com/squareup/convention/AppConvention.kt
@@ -19,7 +19,7 @@ class AppConvention : Plugin<Project> {
     with(pluginManager) {
       apply(BaseConvention::class.java)
       apply("application")
-      apply("com.github.johnrengelman.shadow")
+      apply("com.gradleup.shadow")
     }
 
     Publishing.setup(this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlinEditor = "0.18"
 mavenPublish = "0.30.0"
 moshi = "1.14.0"
 retrofit = "2.9.0"
-shadow = "8.1.0"
+shadow = "8.3.5"
 
 [libraries]
 clikt = "com.github.ajalt.clikt:clikt:4.2.2"
@@ -20,7 +20,7 @@ moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
-shadow-gradle-plugin = { module = "com.github.johnrengelman:shadow", version.ref = "shadow" }
+shadow-gradle-plugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
 maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 slf4j = "org.slf4j:slf4j-simple:2.0.5"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-antlr = "4.10.1"
 dagp = "1.30.0"
+# java is referenced from build-logic
 java = "11"
 junit5 = "5.7.2"
 kotlin = "1.9.24"
@@ -11,12 +11,9 @@ retrofit = "2.9.0"
 shadow = "8.1.0"
 
 [libraries]
-antlr-core = { module = "org.antlr:antlr4", version.ref = "antlr" }
-antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
 clikt = "com.github.ajalt.clikt:clikt:4.2.2"
 grammar = "com.autonomousapps:gradle-script-grammar:0.4"
 kotlinEditor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlinEditor" }
-kotlinEditor-grammar = { module = "app.cash.kotlin-editor:grammar", version.ref = "kotlinEditor" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}
 okhttp3 = "com.squareup.okhttp3:okhttp:4.9.0"
 moshi-core = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
@@ -27,6 +24,7 @@ shadow-gradle-plugin = { module = "com.github.johnrengelman:shadow", version.ref
 maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 slf4j = "org.slf4j:slf4j-simple:2.0.5"
 
+# junit-api, junit-engine, and truth are all referenced from build-logic
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 spock = "org.spockframework:spock-core:2.1-groovy-3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-dagp = "1.30.0"
+dagp = "2.6.1"
 # java is referenced from build-logic
 java = "11"
-junit5 = "5.7.2"
-kotlin = "1.9.24"
-kotlinEditor = "0.10"
-mavenPublish = "0.28.0"
+junit5 = "5.11.4"
+kotlin = "1.9.25"
+kotlinEditor = "0.18"
+mavenPublish = "0.30.0"
 moshi = "1.14.0"
 retrofit = "2.9.0"
 shadow = "8.1.0"
 
 [libraries]
 clikt = "com.github.ajalt.clikt:clikt:4.2.2"
-grammar = "com.autonomousapps:gradle-script-grammar:0.4"
+grammar = "com.autonomousapps:gradle-script-grammar:0.5"
 kotlinEditor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlinEditor" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}
 okhttp3 = "com.squareup.okhttp3:okhttp:4.9.0"

--- a/sort/src/test/groovy/com/squareup/sort/DependencyComparatorTest.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/DependencyComparatorTest.groovy
@@ -1,10 +1,10 @@
 package com.squareup.sort
 
 import cash.grammar.kotlindsl.model.DependencyDeclaration.Capability
+import cash.grammar.kotlindsl.model.DependencyDeclaration.Identifier
 import cash.grammar.kotlindsl.model.DependencyDeclaration.Type
 import com.squareup.sort.kotlin.KotlinDependencyDeclaration
 import spock.lang.Specification
-import cash.grammar.kotlindsl.model.DependencyDeclaration.Identifier
 
 class DependencyComparatorTest extends Specification {
 
@@ -15,7 +15,8 @@ class DependencyComparatorTest extends Specification {
       moduleDependency('implementation', '"b:1.0"', 'implementation("b:1.0")'),
       moduleDependency('implementation', '"a:1.0"', 'implementation("a:1.0")'),
       moduleDependency('implementation', 'deps.foo', 'implementation(deps.foo)'),
-      moduleDependency('implementation', 'deps.bar', 'implementation(deps.bar)', '  /*\n   * Here\'s a multiline comment.\n   */'),
+      moduleDependency('implementation', 'deps.bar', 'implementation(deps.bar)',
+        '  /*\n   * Here\'s a multiline comment.\n   */'),
       projectDependency('implementation', '":milliways"', 'implementation(project(":milliways"))'),
     ]
 
@@ -44,7 +45,11 @@ class DependencyComparatorTest extends Specification {
       capability,
       Type.MODULE,
       fullText,
-      comment
+      null, // producerConfiguration
+      null, // classifier
+      null, // ext
+      comment, // precedingComment
+      false, // isComplex
     )
 
     return new KotlinDependencyDeclaration(base)
@@ -63,7 +68,11 @@ class DependencyComparatorTest extends Specification {
       capability,
       Type.PROJECT,
       fullText,
-      comment
+      null, // producerConfiguration
+      null, // classifier
+      null, // ext
+      comment, // precedingComment
+      false, // isComplex
     )
 
     return new KotlinDependencyDeclaration(base)


### PR DESCRIPTION
Resolves https://github.com/square/gradle-dependencies-sorter/issues/128 (I think)