### PR TITLE
Skip sortDependencies when build script hasn't changed

### DIFF
--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -55,6 +55,7 @@ class SortDependenciesPlugin : Plugin<Project> {
     sortProgram.setFrom(sortApp)
     version.set(extension.version)
     insertBlankLines.set(extension.insertBlankLines)
+    markerFile.set(project.layout.buildDirectory.file("sort-dependencies-marker"))
   }
 
   private fun CheckSortDependenciesTask.configure(

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesTask.kt
@@ -17,12 +17,25 @@ abstract class SortDependenciesTask @Inject constructor(
 
     @Suppress("LeakingThis")
     doNotTrackState("This task modifies build scripts in place.")
+
+    // Skip the expensive javaexec when the build script hasn't been modified since the last sort,
+    // using a marker file's timestamp as the reference point.
+    @Suppress("LeakingThis")
+    onlyIf {
+      val marker = markerFile.get().asFile
+      !marker.exists() || buildScript.get().asFile.lastModified() > marker.lastModified()
+    }
   }
 
   // Not really "internal", but the input and the output are the same: this task will potentially modify the build
   // script in place.
   @get:Internal
   abstract val buildScript: RegularFileProperty
+
+  // Not a real output — doNotTrackState disables all tracking. This is only used by the onlyIf
+  // check to skip re-sorting unchanged build scripts based on the marker's timestamp.
+  @get:Internal
+  abstract val markerFile: RegularFileProperty
 
   @TaskAction fun action() {
     val buildScript = buildScript.get().asFile.absolutePath
@@ -59,6 +72,13 @@ abstract class SortDependenciesTask @Inject constructor(
           }
         }
       }
+    }
+
+    // Touch the marker file so the onlyIf check can skip future runs. writeBytes is used instead
+    // of createNewFile because the latter is a no-op when the file already exists.
+    markerFile.get().asFile.apply {
+      parentFile.mkdirs()
+      writeBytes(ByteArray(0))
     }
   }
 


### PR DESCRIPTION
## Summary

The sort task uses `doNotTrackState` because it modifies build scripts in-place. Without any skip mechanism, Gradle re-runs it on every invocation — spawning a JVM for each module even when nothing changed. In a project with 100+ modules, this adds up.

This adds a timestamp-based skip via `onlyIf` + a marker file:
- After a successful sort, a marker file is touched in the build directory
- On subsequent runs, if the build script's `lastModified` is older than the marker's, the task is skipped before `doNotTrackState` even comes into play
- If the build script is modified, its `lastModified` becomes newer than the marker, and the task runs again

Closes #108 (for the sort task — the check task was already addressed in #115).