### PR TITLE
Make sorting of `files()` dependencies stable

### DIFF
--- a/sort/src/main/kotlin/com/squareup/sort/DependencyComparator.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/DependencyComparator.kt
@@ -48,7 +48,7 @@ internal class DependencyComparator : Comparator<DependencyDeclaration> {
 
     if (left.isFileDependency() && right.isFileDependency()) return compareDependencies(left, right)
     if (left.isFileDependency()) return -1
-    if (right.isFileDependency()) return -1
+    if (right.isFileDependency()) return 1
 
     return compareDependencies(left, right)
   }

--- a/sort/src/test/groovy/com/squareup/sort/DependencyComparatorTest.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/DependencyComparatorTest.groovy
@@ -18,6 +18,7 @@ class DependencyComparatorTest extends Specification {
       moduleDependency('implementation', 'deps.bar', 'implementation(deps.bar)',
         '  /*\n   * Here\'s a multiline comment.\n   */'),
       projectDependency('implementation', '":milliways"', 'implementation(project(":milliways"))'),
+      fileDependency('implementation', '"libs/whatever.jar"', 'implementation(files("libs/whatever.jar"))'),
     ]
 
     when:
@@ -25,11 +26,60 @@ class DependencyComparatorTest extends Specification {
 
     then:
     deps[0].base.identifier.path == '":milliways"'
-    deps[1].base.identifier.path == '"a:1.0"'
-    deps[2].base.identifier.path == '"b:1.0"'
-    deps[3].base.identifier.path == '"heart:of-gold:1.0"'
-    deps[4].base.identifier.path == 'deps.bar'
-    deps[5].base.identifier.path == 'deps.foo'
+    deps[1].base.identifier.path == '"libs/whatever.jar"'
+    deps[2].base.identifier.path == '"a:1.0"'
+    deps[3].base.identifier.path == '"b:1.0"'
+    deps[4].base.identifier.path == '"heart:of-gold:1.0"'
+    deps[5].base.identifier.path == 'deps.bar'
+    deps[6].base.identifier.path == 'deps.foo'
+  }
+
+  def "sorting dependency declarations is stable"() {
+    given:
+    def deps = [
+      moduleDependency('implementation', '"heart:of-gold:1.0"', 'implementation("heart:of-gold:1.0")'),
+      moduleDependency('implementation', '"b:1.0"', 'implementation("b:1.0")'),
+      moduleDependency('implementation', '"a:1.0"', 'implementation("a:1.0")'),
+      moduleDependency('implementation', 'deps.foo', 'implementation(deps.foo)'),
+      moduleDependency('implementation', 'deps.bar', 'implementation(deps.bar)',
+        '  /*\n   * Here\'s a multiline comment.\n   */'),
+      projectDependency('implementation', '":milliways"', 'implementation(project(":milliways"))'),
+      fileDependency('implementation', '"libs/whatever.jar"', 'implementation(files("libs/whatever.jar"))'),
+    ]
+
+    when:
+    Collections.sort(deps, new DependencyComparator())
+    def firstPass = deps.collect { it.base.identifier.path }
+
+    // Sort again to verify stability
+    Collections.sort(deps, new DependencyComparator())
+    def secondPass = deps.collect { it.base.identifier.path }
+
+    then:
+    firstPass == secondPass
+  }
+
+  private static KotlinDependencyDeclaration fileDependency(
+    String configuration,
+    String identifier,
+    String fullText,
+    String comment = null,
+    Capability capability = Capability.DEFAULT
+  ) {
+    def base = new cash.grammar.kotlindsl.model.DependencyDeclaration(
+      configuration,
+      new Identifier(identifier),
+      capability,
+      Type.FILE,
+      fullText,
+      null, // producerConfiguration
+      null, // classifier
+      null, // ext
+      comment, // precedingComment
+      false, // isComplex
+    )
+
+    return new KotlinDependencyDeclaration(base)
   }
 
   private static KotlinDependencyDeclaration moduleDependency(


### PR DESCRIPTION
For `files()` dependencies, `DependencyComparator` currently treats both sides of the sort as smaller than the other, meaning sorting across multiple passes results in different outputs. Easy fix, following convention in the `DependencyComparator` class to always call right bigger than left.

Resolves #144.