### PR TITLE
Don't register tasks for projects without a build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # gradle-dependencies-sorter
 
+## Unreleased
+* [Fix]: don't register tasks for projects without a build script. Applying the plugin to an intermediate "container" project (e.g. `:sub` in `include(":sub:project")`) wired a non-existent build file as a required task input, which Gradle's strict input validation fails as a hard error under Gradle 9.
+
 ## Version 0.19.0
 * [Feat]: support parsing and sorting dependencies blocks with dot syntax.
 

--- a/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
+++ b/sort-dependencies-gradle-plugin/src/main/kotlin/com/squareup/sort/SortDependenciesPlugin.kt
@@ -16,6 +16,16 @@ class SortDependenciesPlugin : Plugin<Project> {
   private lateinit var extension: SortDependenciesExtension
 
   override fun apply(target: Project): Unit = target.run {
+    // A project without a build script — e.g. an intermediate "container" project that
+    // Gradle synthesizes for a nested path such as `:sub:project` — has no dependencies
+    // to sort. Registering the tasks anyway would wire a non-existent build script as a
+    // required @InputFile, which Gradle's strict input validation rejects as a hard
+    // error (as of Gradle 9; a deprecation warning before that). Nothing to do here.
+    if (!buildFile.exists()) {
+      logger.info("sort-dependencies: skipping '$path'; it has no build script.")
+      return@run
+    }
+
     extension = SortDependenciesExtension.create(this)
 
     // nb: Can't use a detached configuration because that needs a Dependency, not a dependency notation. The latter can

--- a/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
+++ b/sort-dependencies-gradle-plugin/src/test/groovy/com/squareup/sort/FunctionalSpec.groovy
@@ -255,6 +255,44 @@ final class FunctionalSpec extends Specification {
     build(dir, 'sortDependencies', '--verbose')
   }
 
+  def "does not register tasks on a project without a build script"() {
+    given: 'A multi-project build whose intermediate `:sub` project has no build script'
+    def settingsScript = dir.resolve('settings.gradle.kts')
+    Files.writeString(settingsScript,
+      """\
+        dependencyResolutionManagement {
+          repositories {
+            mavenCentral()
+            maven { url = uri("$REPO") }
+          }
+        }
+
+        include(":sub:project")""".stripIndent()
+    )
+    def rootBuildScript = dir.resolve('build.gradle.kts')
+    Files.writeString(rootBuildScript,
+      '''\
+      plugins {
+        `java-library`
+        id("com.squareup.sort-dependencies")
+      }
+
+      subprojects {
+        apply(plugin = "com.squareup.sort-dependencies")
+      }'''.stripIndent()
+    )
+    def subproject = dir.resolve('sub/project/build.gradle.kts')
+    Files.createDirectories(subproject.parent)
+    Files.createFile(subproject)
+
+    when: 'We check dependency sorting across the build'
+    def result = build(dir, 'checkSortDependencies')
+
+    then: 'The scriptless container project registers no task, while the leaf project does'
+    result.task(':sub:checkSortDependencies') == null
+    result.task(':sub:project:checkSortDependencies') != null
+  }
+
   def "no blank lines between different configurations when flag is disabled"() {
     given: 'A build script with unsorted dependencies and multiple configurations'
     def buildScript = dir.resolve('build.gradle.kts')


### PR DESCRIPTION
Applying the plugin to a project without a build script — the intermediate "container" projects Gradle synthesizes for nested paths, e.g. `:sub` in `include(":sub:project")` — registers tasks whose required `buildScript` `@InputFile` points at a non-existent file. Gradle 9 fails this as a hard error (it was only a deprecation warning before). The CLI already ignores non-existent build scripts (#79); this does the same on the plugin side by skipping task registration for scriptless projects.

Adds a functional test (fails without the fix, passes with it).