### PR TITLE
fix partial matches being sorted backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # gradle-dependencies-sorter
 
+## Unreleased
+* [Fix]: fix partial matches in the dependency types being sorted backwards.
+
 ## Version 0.20.0
 * [Feat]: bump kotlin-editor.
 * [Feat]: bump gradle-script-grammar.

--- a/sort/src/main/kotlin/com/squareup/sort/Configuration.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/Configuration.kt
@@ -85,7 +85,7 @@ internal class Configuration(
       // If each maps to the same configuration, we now differentiate based on whether variants are
       // involved. Non-variants are "higher than" variants.
       if (leftC.variant != null && rightC.variant != null) {
-        return rightC.variant!!.compareTo(leftC.variant!!)
+        return leftC.variant!!.compareTo(rightC.variant!!)
       }
       return if (rightC.variant != null) return -1 else 1
     }

--- a/sort/src/test/groovy/com/squareup/sort/ConfigurationSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/ConfigurationSpec.groovy
@@ -23,8 +23,8 @@ final class ConfigurationSpec extends Specification {
     then:
     assertThat(configurations).containsExactly(
       'api',
-      'fooApi',
       'debugApi',
+      'fooApi',
       'implementation',
       'releaseImplementation',
       'compileOnlyApi',


### PR DESCRIPTION
Fix for Issue 157: In one of the compareTo calls, left and right are fliped. This change corrects that, to ensure in all cases the last order of sorting is alphabetical.