### PR TITLE
Add missing android dependencies to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * [Fix]: fix partial matches in the dependency types being sorted backwards.
+* [Fix]: add missing dependency types `androidTestCompileOnly` and `androidTestRuntimeOnly`.
 
 ## Version 0.20.0
 * [Feat]: bump kotlin-editor.

--- a/sort/src/main/kotlin/com/squareup/sort/Configuration.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/Configuration.kt
@@ -25,6 +25,8 @@ internal class Configuration(
       "testCompileOnly" to { Configuration("testCompileOnly", 10) },
       "testRuntimeOnly" to { Configuration("testRuntimeOnly", 11) },
       "androidTestImplementation" to { Configuration("androidTestImplementation", 12) },
+	  "androidTestCompileOnly" to { Configuration("androidTestCompileOnly", 13) },
+	  "androidTestRuntimeOnly" to { Configuration("androidTestRuntimeOnly", 14) },
     )
 
     fun of(configurationName: String): Configuration? {

--- a/sort/src/test/groovy/com/squareup/sort/ConfigurationSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/ConfigurationSpec.groovy
@@ -11,8 +11,8 @@ final class ConfigurationSpec extends Specification {
     def configurations = [
       'implementation', 'api', 'releaseImplementation', 'debugApi', 'fooApi', 'kapt',
       'annotationProcessor', 'runtimeOnly', 'compileOnly', 'compileOnlyApi', 'testRuntimeOnly',
-      'testCompileOnly', 'testImplementation', 'androidTestImplementation',
-      'antlr', 'foo', 'bar', 'baz'
+      'testCompileOnly', 'testImplementation', 'androidTestImplementation', 'androidTestRuntimeOnly',
+      'antlr', 'foo', 'bar', 'baz', 'androidTestCompileOnly'
     ]
 
     when:
@@ -36,6 +36,8 @@ final class ConfigurationSpec extends Specification {
       'testCompileOnly',
       'testRuntimeOnly',
       'androidTestImplementation',
+      'androidTestCompileOnly',
+      'androidTestRuntimeOnly',
       'antlr',
       'bar',
       'baz',


### PR DESCRIPTION
Fix for Issue 159: In the list of dependency-type, two ones are missing. "androidTestCompileOnly" and "androidTestRuntimeOnly". I added them after the "androidTestImplementation" so that the "android*" dependencies have the same internal sorting as the normal "test" dependencies above it.