### PR TITLE
Bump gradle-script-grammar to sort type-safe project dependencies before external libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 * [Feat]: bump kotlin-editor.
+* [Feat]: bump gradle-script-grammar.
 * [Fix]: don't register tasks for projects without a build script. Applying the plugin to an intermediate "container" project (e.g. `:sub` in `include(":sub:project")`) wired a non-existent build file as a required task input, which Gradle's strict input validation fails as a hard error under Gradle 9.
-* [Fix]: sort type-safe project dependencies before external libraries in Kotlin DSL.
+* [Fix]: sort type-safe project dependencies before external libraries.
 
 ## Version 0.19.0
 * [Feat]: support parsing and sorting dependencies blocks with dot syntax.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ shadow = "8.3.5"
 
 [libraries]
 clikt = "com.github.ajalt.clikt:clikt:4.2.2"
-grammar = "com.autonomousapps:gradle-script-grammar:0.5"
+grammar = "com.autonomousapps:gradle-script-grammar:0.6"
 kotlinEditor-core = { module = "app.cash.kotlin-editor:core", version.ref = "kotlinEditor" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin"}

--- a/sort/src/main/kotlin/com/squareup/sort/groovy/GroovyDependencyDeclaration.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/groovy/GroovyDependencyDeclaration.kt
@@ -71,7 +71,9 @@ internal class GroovyDependencyDeclaration(
         // If project(path: 'foo') syntax is used, take the path value.
         // Else, if project('foo') syntax is used, take the ID.
         projectMapEntry().firstOrNull { it.key.text == "path:" }?.value?.text
-          ?: ID().text
+          ?: ID()?.text
+          ?: PROJECT_ACCESSOR()?.text
+          ?: text
       }
 
       isFileDependency() -> dependency.fileDependency().ID().text

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -52,6 +52,10 @@ final class GroovySorterSpec extends Specification {
             // Here's a multi-line comment
             // Here's the second line of the comment
             implementation deps.foo
+            api projects.foo
+            implementation projects.foo.internal
+            api projects.bar
+            implementation projects.bar.internal
 
             /*
              * Here's a multiline comment.
@@ -97,9 +101,13 @@ final class GroovySorterSpec extends Specification {
 
           dependencies {
             api project(":marvin")
+            api projects.bar
+            api projects.foo
             api 'zzz:yyy:1.0'
 
             implementation project(':milliways')
+            implementation projects.bar.internal
+            implementation projects.foo.internal
             implementation 'a:1.0'
             implementation 'b:1.0'
             implementation 'heart:of-gold:1.0'
@@ -682,6 +690,7 @@ final class GroovySorterSpec extends Specification {
     def fileContent = normalize('''\
         dependencies {
           implementation projects.foo.internal
+          implementation project(":marvin")
           implementation projects.bar.public
           implementation (libs.baz.ui) {
             artifact {
@@ -705,6 +714,10 @@ final class GroovySorterSpec extends Specification {
     assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
       '''\
         dependencies {
+          implementation project(":marvin")
+          implementation projects.bar.public
+          implementation projects.core
+          implementation projects.foo.internal
           implementation libs.androidx.constraintLayout
           implementation (libs.baz.ui) {
             artifact {
@@ -712,9 +725,6 @@ final class GroovySorterSpec extends Specification {
             }
           }
           implementation libs.common.view
-          implementation projects.bar.public
-          implementation projects.core
-          implementation projects.foo.internal
         }'''.stripIndent()
     )).inOrder()
 
@@ -757,8 +767,8 @@ final class GroovySorterSpec extends Specification {
             dependencies {
               api projects.redwoodLayoutWidget
               implementation projects.redwoodFlexbox
-              implementation projects.redwoodWidgetCompose
               implementation libs.jetbrains.compose.foundation
+              implementation projects.redwoodWidgetCompose
             }
           }
 
@@ -813,9 +823,9 @@ final class GroovySorterSpec extends Specification {
             dependencies {
               api projects.redwoodLayoutWidget
 
-              implementation libs.jetbrains.compose.foundation
               implementation projects.redwoodFlexbox
               implementation projects.redwoodWidgetCompose
+              implementation libs.jetbrains.compose.foundation
       }
           }
 


### PR DESCRIPTION
In `gradle-script-grammar` v0.6 type-safe project dependencies are parsed as project type