### PR TITLE
Cover nested dependencies block indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gradle-dependencies-sorter
 
 ## Unreleased
+* [Fix]: preserve indentation in nested dependencies blocks.
 * [Fix]: fix partial matches in the dependency types being sorted backwards.
 
 ## Version 0.20.0

--- a/sort/src/main/kotlin/com/squareup/sort/Ordering.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/Ordering.kt
@@ -1,0 +1,32 @@
+package com.squareup.sort
+
+/** Tracks the original and rewritten dependency order for each `dependencies` block. */
+internal class Ordering<T : DependencyDeclaration>(
+  private val sameDependency: (T, T) -> Boolean = { first, second -> first == second },
+) {
+
+  private val dependenciesInOrder = mutableListOf<T>()
+  private val orderedBlocks = mutableListOf<Boolean>()
+
+  fun isAlreadyOrdered(): Boolean = orderedBlocks.all { it }
+
+  fun add(dependency: T) {
+    dependenciesInOrder += dependency
+  }
+
+  fun addAll(dependencies: List<T>) {
+    dependenciesInOrder += dependencies
+  }
+
+  /**
+   * Checks ordering as we leave a dependencies block, then clears the collected order so the next block is checked
+   * separately.
+   */
+  fun checkOrdering(newOrder: List<T>): Boolean {
+    val isAlreadyOrdered = dependenciesInOrder.size == newOrder.size &&
+      dependenciesInOrder.zip(newOrder).all { (first, second) -> sameDependency(first, second) }
+    orderedBlocks += isAlreadyOrdered
+    dependenciesInOrder.clear()
+    return isAlreadyOrdered
+  }
+}

--- a/sort/src/main/kotlin/com/squareup/sort/RewrittenBlock.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/RewrittenBlock.kt
@@ -1,0 +1,6 @@
+package com.squareup.sort
+
+internal data class RewrittenBlock(
+  val text: String,
+  val isAlreadyOrdered: Boolean,
+)

--- a/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
@@ -13,12 +13,13 @@ import com.squareup.parse.AbstractErrorListener
 import com.squareup.parse.AlreadyOrderedException
 import com.squareup.parse.BuildScriptParseException
 import com.squareup.sort.DependencyComparator
+import com.squareup.sort.Ordering
+import com.squareup.sort.RewrittenBlock
 import com.squareup.sort.Sorter
 import com.squareup.sort.Texts
 import com.squareup.utils.ifNotEmpty
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.TokenStreamRewriter
@@ -37,40 +38,27 @@ public class GroovySorter private constructor(
   private val lineSeparator: String,
 ) : Sorter, GradleScriptBaseListener() {
 
-  // We use a default of two spaces, but update it at most once later on.
-  private var smartIndentSet = false
-  private var indent = "  "
-
   // TODO we can probably sort this block too.
   private var isInBuildScriptBlock = false
 
   private val dependencyComparator = DependencyComparator()
   private val dependenciesByConfiguration =
     mutableMapOf<String, MutableList<GroovyDependencyDeclaration>>()
-  private val ordering = Ordering(tokens)
+  private val ordering = Ordering<GroovyDependencyDeclaration> { first, second ->
+    tokens.getText(first.declaration) == tokens.getText(second.declaration)
+  }
 
   private fun collectDependency(
     configuration: String,
     dependencyDeclaration: GroovyDependencyDeclaration
   ) {
-    setIndent(dependencyDeclaration.declaration)
-    ordering.collectDependency(dependencyDeclaration)
+    ordering.add(dependencyDeclaration)
     dependenciesByConfiguration.merge(
       configuration,
       mutableListOf(dependencyDeclaration)
     ) { acc, inc ->
       acc.apply { addAll(inc) }
     }
-  }
-
-  private fun setIndent(ctx: ParserRuleContext) {
-    if (smartIndentSet) return
-
-    tokens.getHiddenTokensToLeft(ctx.start.tokenIndex, GradleScriptLexer.WHITESPACE)
-      ?.firstOrNull()?.text?.replace("\n", "")?.let {
-        smartIndentSet = true
-        indent = it
-      }
   }
 
   /**
@@ -147,47 +135,71 @@ public class GroovySorter private constructor(
 
   override fun exitDependencies(ctx: DependenciesContext) {
     if (isInBuildScriptBlock) return
-    rewriter.replace(ctx.start, ctx.stop, dependenciesBlock())
+    val rewrittenBlock = dependenciesBlock(ctx)
+    // Leave sorted blocks untouched so their existing formatting is preserved.
+    if (!rewrittenBlock.isAlreadyOrdered) {
+      rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+    }
 
     // Whenever we exit a dependencies block, clear this map. Each block will be treated separately.
     dependenciesByConfiguration.clear()
   }
 
-  private fun dependenciesBlock() = buildString {
+  private fun dependenciesBlock(ctx: DependenciesContext): RewrittenBlock {
     val newOrder = mutableListOf<GroovyDependencyDeclaration>()
 
-    appendLine("dependencies {")
-    dependenciesByConfiguration.entries.sortedWith(GroovyConfigurationComparator)
-      .forEachIndexed { i, entry ->
-        // Place a blank line between chunks of the same configuration, if configured
-        if (i != 0 && config.insertBlankLines) appendLine()
+    // Blocks can be nested inside any DSL, so derive indentation from this block's source text.
+    val blockIndent = indentationBefore(ctx.start.tokenIndex).orEmpty()
+    val bodyIndent = dependenciesByConfiguration.values.asSequence()
+      .flatten()
+      .minByOrNull { it.declaration.start.tokenIndex }
+      ?.let { indentationBefore(it.declaration.start.tokenIndex) }
+      ?: "$blockIndent  "
+    val text = buildString {
+      appendLine("${ctx.start.text.substringBeforeLast('{').trimEnd()} {")
+      dependenciesByConfiguration.entries.sortedWith(GroovyConfigurationComparator)
+        .forEachIndexed { i, entry ->
+          // Place a blank line between chunks of the same configuration, if configured
+          if (i != 0 && config.insertBlankLines) appendLine()
 
-        entry.value.sortedWith(dependencyComparator)
-          .map { dependency ->
-            dependency to Texts(
-              comment = precedingComment(dependency),
-              declarationText = tokens.getText(dependency.declaration),
-            )
-          }
-          .distinctBy { (_, texts) -> texts }
-          .forEach { (declaration, texts) ->
-            newOrder += declaration
+          entry.value.sortedWith(dependencyComparator)
+            .map { dependency ->
+              dependency to Texts(
+                comment = precedingComment(dependency, bodyIndent),
+                declarationText = tokens.getText(dependency.declaration),
+              )
+            }
+            .distinctBy { (_, texts) -> texts }
+            .forEach { (declaration, texts) ->
+              newOrder += declaration
 
-            // Write preceding comments if there are any
-            if (texts.comment != null) appendLine(texts.comment.replace("\r", ""))
+              // Write preceding comments if there are any
+              if (texts.comment != null) appendLine(texts.comment.replace("\r", ""))
 
-            append(indent.replace("\r", ""))
-            appendLine(texts.declarationText.replace("\r", ""))
-          }
-      }
-    append("}")
+              append(bodyIndent.replace("\r", ""))
+              appendLine(texts.declarationText.replace("\r", ""))
+            }
+        }
+      append(blockIndent)
+      append("}")
+    }.replace("\n", lineSeparator)
 
-    // If the new ordering matches the old ordering, we shouldn't rewrite the file. This accounts for multiple
-    // dependencies blocks
-    ordering.checkOrdering(newOrder)
-  }.replace("\n", lineSeparator)
+    return RewrittenBlock(
+      text = text,
+      isAlreadyOrdered = ordering.checkOrdering(newOrder),
+    )
+  }
 
-  private fun precedingComment(dependency: GroovyDependencyDeclaration) =
+  private fun indentationBefore(tokenIndex: Int): String? {
+    return tokens.getHiddenTokensToLeft(tokenIndex, GradleScriptLexer.WHITESPACE)
+      ?.lastOrNull()
+      ?.text
+      ?.substringAfterLast('\n')
+      ?.substringAfterLast('\r')
+      ?.takeIf { it.all { char -> char == ' ' || char == '\t' } }
+  }
+
+  private fun precedingComment(dependency: GroovyDependencyDeclaration, indent: String) =
     tokens.getHiddenTokensToLeft(
       dependency.declaration.start.tokenIndex,
       GradleScriptLexer.COMMENTS
@@ -243,38 +255,5 @@ internal class RewriterErrorListener : AbstractErrorListener() {
     e: RecognitionException?
   ) {
     errorMessages.add(msg)
-  }
-}
-
-private class Ordering(
-  private val tokens: CommonTokenStream,
-) {
-
-  private val dependenciesInOrder = mutableListOf<GroovyDependencyDeclaration>()
-  private val orderedBlocks = mutableListOf<Boolean>()
-
-  fun isAlreadyOrdered(): Boolean = orderedBlocks.all { it }
-
-  fun collectDependency(dependency: GroovyDependencyDeclaration) {
-    dependenciesInOrder += dependency
-  }
-
-  /**
-   * Checks ordering as we leave a dependencies block. Clears the list of dependencies to prepare for the potential next
-   * block.
-   */
-  fun checkOrdering(newOrder: List<GroovyDependencyDeclaration>) {
-    orderedBlocks += isSameOrder(dependenciesInOrder, newOrder)
-    dependenciesInOrder.clear()
-  }
-
-  private fun isSameOrder(
-    first: List<GroovyDependencyDeclaration>,
-    second: List<GroovyDependencyDeclaration>
-  ): Boolean {
-    if (first.size != second.size) return false
-    return first.zip(second).all { (l, r) ->
-      tokens.getText(l.declaration) == tokens.getText(r.declaration)
-    }
   }
 }

--- a/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
@@ -13,12 +13,16 @@ import com.squareup.cash.grammar.KotlinParserBaseListener
 import com.squareup.parse.AlreadyOrderedException
 import com.squareup.parse.BuildScriptParseException
 import com.squareup.sort.DependencyComparator
+import com.squareup.sort.Ordering
+import com.squareup.sort.RewrittenBlock
 import com.squareup.sort.Sorter
 import com.squareup.sort.Texts
 import com.squareup.utils.ifNotEmpty
 import org.antlr.v4.runtime.CharStream
 import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.TokenStreamRewriter
+import org.antlr.v4.runtime.misc.Interval
 import java.nio.file.Path
 
 public class KotlinSorter private constructor(
@@ -40,9 +44,7 @@ public class KotlinSorter private constructor(
 
   private val dependencyComparator = DependencyComparator()
   private val mutableDependencies = MutableDependencies()
-  private val ordering = Ordering()
-
-  private var level = 0
+  private val ordering = Ordering<KotlinDependencyDeclaration>()
 
   /**
    * Returns the sorted build script.
@@ -78,7 +80,6 @@ public class KotlinSorter private constructor(
 
   override fun enterNamedBlock(ctx: NamedBlockContext) {
     dependencyExtractor.onEnterBlock()
-    level++
 
     if (ctx.isDependencies) {
       collectDependencies(dependencyExtractor.collectDependencies(ctx))
@@ -87,21 +88,25 @@ public class KotlinSorter private constructor(
 
   override fun exitNamedBlock(ctx: NamedBlockContext) {
     if (ctx.isDependencies) {
-      rewriter.replace(ctx.start, ctx.stop, dependenciesBlock(ctx))
+      val rewrittenBlock = dependenciesBlock(ctx)
+
+      // Leave sorted blocks untouched so their existing formatting is preserved.
+      if (!rewrittenBlock.isAlreadyOrdered) {
+        rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+      }
 
       // Whenever we exit a dependencies block, clear this map. Each block will be treated separately.
       mutableDependencies.clear()
     }
 
     dependencyExtractor.onExitBlock()
-    level--
   }
 
   private fun collectDependencies(container: DependencyContainer) {
     val declarations = container.getDependencyDeclarations().map { KotlinDependencyDeclaration(it) }
     mutableDependencies.statements += container.getStatements()
 
-    ordering.collectDependencies(declarations)
+    ordering.addAll(declarations)
 
     declarations.forEach { decl ->
       mutableDependencies.dependenciesByConfiguration.merge(
@@ -113,73 +118,91 @@ public class KotlinSorter private constructor(
     }
   }
 
-  private fun dependenciesBlock(ctx: NamedBlockContext) = buildString {
+  private fun dependenciesBlock(ctx: NamedBlockContext): RewrittenBlock {
     val newOrder = mutableListOf<KotlinDependencyDeclaration>()
-    var didWrite = false
 
-    appendLine("${ctx.name().text} {")
+    // Blocks can be nested inside any DSL, so derive indentation from this block's source text.
+    val blockIndent = indentationBefore(ctx.start).orEmpty()
+    val bodyIndent = ctx.statements().statement().firstOrNull()
+      ?.let { indentationBefore(it.start) }
+      ?: "$blockIndent$indent"
+    val text = buildString {
+      var didWrite = false
 
-    /*
-     * not-easily-modelable elements
-     */
+      appendLine("${ctx.name().text} {")
 
-    // An example of a statement, in this context, is an if-expression or property expression (declaration)
-    mutableDependencies.statements.forEach { stmt ->
-      append(indent.repeat(level))
-      appendLine(stmt.fullText(input)!!)
+      /*
+       * not-easily-modelable elements
+       */
 
-      didWrite = true
-    }
+      // An example of a statement, in this context, is an if-expression or property expression (declaration)
+      mutableDependencies.statements.forEach { stmt ->
+        append(bodyIndent)
+        appendLine(stmt.fullText(input)!!)
 
-    if (didWrite && mutableDependencies.expressions.isNotEmpty()) {
-      appendLine()
-    }
-
-    // An example of an expression, in this context, is a function call like `add("extraImplementation", "foo")`
-    mutableDependencies.expressions.forEach { expr ->
-      append(indent.repeat(level))
-      appendLine(expr)
-
-      didWrite = true
-    }
-
-    if (didWrite && mutableDependencies.declarations().isNotEmpty()) {
-      appendLine()
-    }
-
-    // straightforward declarations
-    mutableDependencies.declarations()
-      .sortedWith(KotlinConfigurationComparator)
-      .forEachIndexed { i, entry ->
-        // Place a blank line between chunks of the same configuration, if configured
-        if (i != 0 && config.insertBlankLines) appendLine()
-
-        entry.value.sortedWith(dependencyComparator)
-          .map { dependency ->
-            dependency to Texts(
-              comment = dependency.precedingComment(),
-              declarationText = dependency.fullText(),
-            )
-          }
-          .distinctBy { (_, texts) -> texts }
-          .forEach { (declaration, texts) ->
-            newOrder += declaration
-
-            // Write preceding comments if there are any
-            if (texts.comment != null) appendLine(texts.comment.replace("\r", ""))
-
-            append(indent.repeat(level))
-            appendLine(texts.declarationText.replace("\r", ""))
-          }
+        didWrite = true
       }
 
-    append(indent.repeat(level - 1))
-    append("}")
+      if (didWrite && mutableDependencies.expressions.isNotEmpty()) {
+        appendLine()
+      }
 
-    // If the new ordering matches the old ordering, we shouldn't rewrite the file. This accounts for multiple
-    // dependencies blocks
-    ordering.checkOrdering(newOrder)
-  }.replace("\n", lineSeparator)
+      // An example of an expression, in this context, is a function call like `add("extraImplementation", "foo")`
+      mutableDependencies.expressions.forEach { expr ->
+        append(bodyIndent)
+        appendLine(expr)
+
+        didWrite = true
+      }
+
+      if (didWrite && mutableDependencies.declarations().isNotEmpty()) {
+        appendLine()
+      }
+
+      // straightforward declarations
+      mutableDependencies.declarations()
+        .sortedWith(KotlinConfigurationComparator)
+        .forEachIndexed { i, entry ->
+          // Place a blank line between chunks of the same configuration, if configured
+          if (i != 0 && config.insertBlankLines) appendLine()
+
+          entry.value.sortedWith(dependencyComparator)
+            .map { dependency ->
+              dependency to Texts(
+                comment = dependency.precedingComment(),
+                declarationText = dependency.fullText(),
+              )
+            }
+            .distinctBy { (_, texts) -> texts }
+            .forEach { (declaration, texts) ->
+              newOrder += declaration
+
+              // Write preceding comments if there are any
+              if (texts.comment != null) appendLine(texts.comment.replace("\r", ""))
+
+              append(bodyIndent)
+              appendLine(texts.declarationText.replace("\r", ""))
+            }
+        }
+
+      append(blockIndent)
+      append("}")
+    }.replace("\n", lineSeparator)
+
+    return RewrittenBlock(
+      text = text,
+      isAlreadyOrdered = ordering.checkOrdering(newOrder),
+    )
+  }
+
+  private fun indentationBefore(token: Token): String? {
+    if (token.startIndex <= 0) return ""
+
+    return input.getText(Interval.of(0, token.startIndex - 1))
+      .substringAfterLast('\n')
+      .substringAfterLast('\r')
+      .takeIf { it.all { char -> char == ' ' || char == '\t' } }
+  }
 
   public companion object {
     @JvmStatic
@@ -217,36 +240,5 @@ private class MutableDependencies(
     dependenciesByConfiguration.clear()
     expressions.clear()
     statements.clear()
-  }
-}
-
-private class Ordering {
-
-  private val dependenciesInOrder = mutableListOf<KotlinDependencyDeclaration>()
-  private val orderedBlocks = mutableListOf<Boolean>()
-
-  fun isAlreadyOrdered(): Boolean = orderedBlocks.all { it }
-
-  fun collectDependencies(dependencies: List<KotlinDependencyDeclaration>) {
-    dependenciesInOrder += dependencies
-  }
-
-  /**
-   * Checks ordering as we leave a dependencies block. Clears the list of dependencies to prepare for the potential next
-   * block.
-   */
-  fun checkOrdering(newOrder: List<KotlinDependencyDeclaration>) {
-    orderedBlocks += isSameOrder(dependenciesInOrder, newOrder)
-    dependenciesInOrder.clear()
-  }
-
-  private fun isSameOrder(
-    first: List<KotlinDependencyDeclaration>,
-    second: List<KotlinDependencyDeclaration>,
-  ): Boolean {
-    if (first.size != second.size) return false
-    return first.zip(second).all { (l, r) ->
-      l == r
-    }
   }
 }

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -826,13 +826,13 @@ final class GroovySorterSpec extends Specification {
               implementation projects.redwoodFlexbox
               implementation projects.redwoodWidgetCompose
               implementation libs.jetbrains.compose.foundation
-      }
+            }
           }
 
           androidUnitTest {
             dependencies {
               implementation projects.redwoodLayoutSharedTest
-      }
+            }
           }
         }
       }
@@ -840,6 +840,40 @@ final class GroovySorterSpec extends Specification {
       android {
         namespace 'app.cash.redwood.layout.composeui'
       }""".stripIndent()
+    )).inOrder()
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
+  def "preserves a qualified nested dependencies block name"() {
+    given:
+    def buildScript = dir.resolve('build.gradle')
+    def fileContent = normalize('''\
+      kotlin {
+        sourceSets.commonMain.dependencies {
+          implementation libs.z
+          implementation libs.a
+        }
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
+
+    when:
+    def config = new Sorter.Config(true)
+    def newScript = GroovySorter.of(buildScript, config, lineSeparator).rewritten()
+
+    then:
+    extractLineSeparators(newScript).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+      kotlin {
+        sourceSets.commonMain.dependencies {
+          implementation libs.a
+          implementation libs.z
+        }
+      }
+      '''.stripIndent()
     )).inOrder()
 
     where:

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -910,6 +910,114 @@ class KotlinSorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
+  // https://github.com/square/gradle-dependencies-sorter/issues/137
+  def "does not rewrite a sorted deeply nested dependencies block"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContents = normalize('''\
+      dependencies {
+        implementation(libs.z)
+        implementation(libs.a)
+      }
+
+      androidComponents {
+        onVariants { variant ->
+          when (variant.name) {
+            "someVariant1",
+            "someVariant2" ->
+              sourceSets {
+                named(variant.name).configure {
+                  dependencies { implementation(projects.infra.someModule) }
+                }
+              }
+            else -> error("unexpected variant")
+          }
+        }
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
+
+    when:
+    def config = new Sorter.Config(true)
+    def newScript = KotlinSorter.of(buildScript, config, lineSeparator).rewritten()
+
+    then:
+    extractLineSeparators(newScript).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+      dependencies {
+        implementation(libs.a)
+        implementation(libs.z)
+      }
+
+      androidComponents {
+        onVariants { variant ->
+          when (variant.name) {
+            "someVariant1",
+            "someVariant2" ->
+              sourceSets {
+                named(variant.name).configure {
+                  dependencies { implementation(projects.infra.someModule) }
+                }
+              }
+            else -> error("unexpected variant")
+          }
+        }
+      }
+      '''.stripIndent()
+    )).inOrder()
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
+  // https://github.com/square/gradle-dependencies-sorter/issues/137
+  def "sorts a deeply nested dependencies block using its indentation"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContents = normalize('''\
+      androidComponents {
+        onVariants { variant ->
+          sourceSets {
+            named(variant.name).configure {
+              dependencies {
+                implementation(projects.infra.z)
+                implementation(projects.infra.a)
+              }
+            }
+          }
+        }
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
+
+    when:
+    def config = new Sorter.Config(true)
+    def newScript = KotlinSorter.of(buildScript, config, lineSeparator).rewritten()
+
+    then:
+    extractLineSeparators(newScript).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+      androidComponents {
+        onVariants { variant ->
+          sourceSets {
+            named(variant.name).configure {
+              dependencies {
+                implementation(projects.infra.a)
+                implementation(projects.infra.z)
+              }
+            }
+          }
+        }
+      }
+      '''.stripIndent()
+    )).inOrder()
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
   // https://github.com/square/gradle-dependencies-sorter/issues/148
   def "can sort source sets usage"() {
     given:


### PR DESCRIPTION
This preserves indentation when sorting nested Kotlin and Groovy `dependencies` blocks while leaving already-sorted blocks untouched. Each block now derives its indentation from its own source text and is rewritten only when _its_ dependency order changes.

Fixes #137