### PR TITLE
fix: preserve constraints formatting on CRLF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gradle-dependencies-sorter
 
 ## Unreleased
+* [Fix]: prevent extra blank lines inside Kotlin dependency constraints in CRLF files.
 * [Fix]: preserve indentation in nested dependencies blocks.
 * [Fix]: fix partial matches in the dependency types being sorted backwards.
 * [Fix]: add missing dependency types `androidTestCompileOnly` and `androidTestRuntimeOnly`.

--- a/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
@@ -138,7 +138,7 @@ public class KotlinSorter private constructor(
       // An example of a statement, in this context, is an if-expression or property expression (declaration)
       mutableDependencies.statements.forEach { stmt ->
         append(bodyIndent)
-        appendLine(stmt.fullText(input)!!)
+        appendLine(stmt.fullText(input)!!.replace("\r", ""))
 
         didWrite = true
       }

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -294,6 +294,52 @@ class KotlinSorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
+  // https://github.com/square/gradle-dependencies-sorter/issues/152
+  def "preserves formatting inside dependency constraints"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContent = normalize('''\
+      dependencies {
+        constraints {
+          testImplementation(libs.example) {
+            version { require("2.0.0") }
+          }
+        }
+        testImplementation(libs.junit)
+        testImplementation(libs.commonsIo)
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
+    def config = new Sorter.Config(insertBlankLines)
+
+    when:
+    def newScript = KotlinSorter.of(buildScript, config, lineSeparator).rewritten()
+
+    then:
+    extractLineSeparators(newScript).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(newScript)).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+      dependencies {
+        constraints {
+          testImplementation(libs.example) {
+            version { require("2.0.0") }
+          }
+        }
+
+        testImplementation(libs.commonsIo)
+        testImplementation(libs.junit)
+      }
+      '''.stripIndent()
+    )).inOrder()
+
+    where:
+    lineSeparator | insertBlankLines
+    '\n'          | true
+    '\n'          | false
+    '\r\n'        | true
+    '\r\n'        | false
+  }
+
   def "can sort build script with four-space tabs"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')


### PR DESCRIPTION
Fixes #152

## Summary

- normalize carriage returns in nested Kotlin dependency statements before applying the configured line separator
- preserve `constraints` block formatting for CRLF build scripts
- cover LF and CRLF with `insertBlankLines` enabled and disabled
- document the fix under Unreleased

## Validation

- `./gradlew :sort:test --tests '*KotlinSorterSpec*constraints*' --no-daemon --console=plain`
- `./gradlew :sort:check --no-daemon --console=plain`
- `./gradlew check --no-daemon --console=plain`
- `git diff --check`
