### PR TITLE
fix: honor blank line configuration for sorted dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gradle-dependencies-sorter
 
 ## Unreleased
+* [Fix]: insert configured blank lines when dependency declarations are already sorted.
 * [Fix]: preserve indentation in nested dependencies blocks.
 * [Fix]: fix partial matches in the dependency types being sorted backwards.
 * [Fix]: add missing dependency types `androidTestCompileOnly` and `androidTestRuntimeOnly`.

--- a/sort/src/main/kotlin/com/squareup/sort/Texts.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/Texts.kt
@@ -1,6 +1,40 @@
 package com.squareup.sort
 
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.Token
+
 internal data class Texts(
   val comment: String?,
   val declarationText: String,
 )
+
+private val lineBreak = Regex("""\r\n|(?<!\r)\n|\r(?!\n)""")
+private val nextLineIsBlank = Regex("^[\t ]*(?:${lineBreak.pattern})")
+
+internal fun missingBlankLineReplacements(
+  declarations: List<Triple<String, Token, Token>>,
+  tokens: CommonTokenStream,
+  lineSeparator: String,
+): List<Pair<Token, String>>? {
+  val replacements = mutableListOf<Pair<Token, String>>()
+  for ((first, second) in declarations.zipWithNext()) {
+    if (first.first == second.first) continue
+    val between = (first.third.tokenIndex + 1 until second.second.tokenIndex).map(tokens::get)
+    if (between.any {
+        it.channel == Token.DEFAULT_CHANNEL && it.text != ";" && !it.text.all(Char::isWhitespace)
+      }) continue
+    val boundary = between.firstOrNull {
+      it.text.any { char -> char == '\r' || char == '\n' } &&
+        (it.text.all(Char::isWhitespace) || it.text.endsWith('\r') || it.text.endsWith('\n'))
+    } ?: return null
+    val following = between.dropWhile { it !== boundary }.joinToString(separator = "") { it.text }
+    val firstLineEnd = lineBreak.find(following)!!.range.last + 1
+    if (!nextLineIsBlank.containsMatchIn(following.substring(firstLineEnd))) {
+      val insertionPoint = lineBreak.find(boundary.text)!!.range.last + 1
+      replacements += boundary to (
+        boundary.text.substring(0, insertionPoint) + lineSeparator + boundary.text.substring(insertionPoint)
+        )
+    }
+  }
+  return replacements
+}

--- a/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/groovy/GroovySorter.kt
@@ -17,11 +17,13 @@ import com.squareup.sort.Ordering
 import com.squareup.sort.RewrittenBlock
 import com.squareup.sort.Sorter
 import com.squareup.sort.Texts
+import com.squareup.sort.missingBlankLineReplacements
 import com.squareup.utils.ifNotEmpty
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
+import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.TokenStreamRewriter
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 import java.nio.file.Files
@@ -44,15 +46,20 @@ public class GroovySorter private constructor(
   private val dependencyComparator = DependencyComparator()
   private val dependenciesByConfiguration =
     mutableMapOf<String, MutableList<GroovyDependencyDeclaration>>()
+  private val dependenciesInSource = mutableListOf<Triple<String, Token, Token>>()
   private val ordering = Ordering<GroovyDependencyDeclaration> { first, second ->
     tokens.getText(first.declaration) == tokens.getText(second.declaration)
   }
+  private var hasRequiredBlankLines = true
 
   private fun collectDependency(
     configuration: String,
     dependencyDeclaration: GroovyDependencyDeclaration
   ) {
     ordering.add(dependencyDeclaration)
+    dependenciesInSource += Triple(
+      configuration, dependencyDeclaration.declaration.start, dependencyDeclaration.declaration.stop
+    )
     dependenciesByConfiguration.merge(
       configuration,
       mutableListOf(dependencyDeclaration)
@@ -79,7 +86,7 @@ public class GroovySorter private constructor(
   }
 
   /** Returns `true` if this file's dependencies are already sorted correctly, or if there are no dependencies. */
-  override fun isSorted(): Boolean = ordering.isAlreadyOrdered()
+  override fun isSorted(): Boolean = ordering.isAlreadyOrdered() && hasRequiredBlankLines
 
   /** Returns `true` if there were errors parsing the build script. */
   override fun hasParseErrors(): Boolean = errorListener.errorMessages.isNotEmpty()
@@ -139,10 +146,21 @@ public class GroovySorter private constructor(
     // Leave sorted blocks untouched so their existing formatting is preserved.
     if (!rewrittenBlock.isAlreadyOrdered) {
       rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+    } else if (config.insertBlankLines) {
+      val replacements = missingBlankLineReplacements(
+        dependenciesInSource, tokens, lineSeparator
+      )
+      if (replacements == null) {
+        rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+      } else {
+        replacements.forEach { (token, replacement) -> rewriter.replace(token, replacement) }
+      }
+      if (replacements == null || replacements.isNotEmpty()) hasRequiredBlankLines = false
     }
 
     // Whenever we exit a dependencies block, clear this map. Each block will be treated separately.
     dependenciesByConfiguration.clear()
+    dependenciesInSource.clear()
   }
 
   private fun dependenciesBlock(ctx: DependenciesContext): RewrittenBlock {

--- a/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/kotlin/KotlinSorter.kt
@@ -17,6 +17,7 @@ import com.squareup.sort.Ordering
 import com.squareup.sort.RewrittenBlock
 import com.squareup.sort.Sorter
 import com.squareup.sort.Texts
+import com.squareup.sort.missingBlankLineReplacements
 import com.squareup.utils.ifNotEmpty
 import org.antlr.v4.runtime.CharStream
 import org.antlr.v4.runtime.CommonTokenStream
@@ -45,6 +46,7 @@ public class KotlinSorter private constructor(
   private val dependencyComparator = DependencyComparator()
   private val mutableDependencies = MutableDependencies()
   private val ordering = Ordering<KotlinDependencyDeclaration>()
+  private var hasRequiredBlankLines = true
 
   /**
    * Returns the sorted build script.
@@ -64,7 +66,7 @@ public class KotlinSorter private constructor(
   }
 
   /** Returns `true` if this file's dependencies are already sorted correctly, or if there are no dependencies. */
-  override fun isSorted(): Boolean = ordering.isAlreadyOrdered()
+  override fun isSorted(): Boolean = ordering.isAlreadyOrdered() && hasRequiredBlankLines
 
   /** Returns `true` if there were errors parsing the build script. */
   override fun hasParseErrors(): Boolean = errorListener.getErrorMessages().isNotEmpty()
@@ -93,6 +95,16 @@ public class KotlinSorter private constructor(
       // Leave sorted blocks untouched so their existing formatting is preserved.
       if (!rewrittenBlock.isAlreadyOrdered) {
         rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+      } else if (config.insertBlankLines) {
+        val replacements = missingBlankLineReplacements(
+          mutableDependencies.declarationsInSource, tokens, lineSeparator
+        )
+        if (replacements == null) {
+          rewriter.replace(ctx.start, ctx.stop, rewrittenBlock.text)
+        } else {
+          replacements.forEach { (token, replacement) -> rewriter.replace(token, replacement) }
+        }
+        if (replacements == null || replacements.isNotEmpty()) hasRequiredBlankLines = false
       }
 
       // Whenever we exit a dependencies block, clear this map. Each block will be treated separately.
@@ -103,12 +115,15 @@ public class KotlinSorter private constructor(
   }
 
   private fun collectDependencies(container: DependencyContainer) {
-    val declarations = container.getDependencyDeclarations().map { KotlinDependencyDeclaration(it) }
+    val declarations = container.getDependencyDeclarationsWithContext().map {
+      KotlinDependencyDeclaration(it.declaration) to it.statement
+    }
     mutableDependencies.statements += container.getStatements()
 
-    ordering.addAll(declarations)
+    ordering.addAll(declarations.map { it.first })
 
-    declarations.forEach { decl ->
+    declarations.forEach { (decl, statement) ->
+      mutableDependencies.declarationsInSource += Triple(decl.configuration, statement.start, statement.stop)
       mutableDependencies.dependenciesByConfiguration.merge(
         decl.configuration,
         mutableListOf(decl)
@@ -230,6 +245,7 @@ public class KotlinSorter private constructor(
 
 private class MutableDependencies(
   val dependenciesByConfiguration: MutableMap<String, MutableList<KotlinDependencyDeclaration>> = mutableMapOf(),
+  val declarationsInSource: MutableList<Triple<String, Token, Token>> = mutableListOf(),
   val expressions: MutableList<String> = mutableListOf(),
   val statements: MutableList<StatementContext> = mutableListOf(),
 ) {
@@ -238,6 +254,7 @@ private class MutableDependencies(
 
   fun clear() {
     dependenciesByConfiguration.clear()
+    declarationsInSource.clear()
     expressions.clear()
     statements.clear()
   }

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -397,6 +397,98 @@ final class GroovySorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
+  def "issue 164 inserts only missing configuration blank lines in sorted blocks"() {
+    given:
+    def buildScript = dir.resolve('build.gradle')
+    def fileContent = normalize('''\
+      dependencies{
+          api libs.foo // Keep this trailing comment in place.
+          /* Keep this multiline comment with the implementation dependency.
+
+             Its internal blank line is not configuration separation. */
+          implementation 'g:bar:1'
+
+          testImplementation libs.baz
+      }
+
+      dependencies {
+        api "g:foo:1"
+
+        implementation libs.bar
+      }
+      ''', lineSeparator)
+    def expected = normalize('''\
+      dependencies{
+          api libs.foo // Keep this trailing comment in place.
+
+          /* Keep this multiline comment with the implementation dependency.
+
+             Its internal blank line is not configuration separation. */
+          implementation 'g:bar:1'
+
+          testImplementation libs.baz
+      }
+
+      dependencies {
+        api "g:foo:1"
+
+        implementation libs.bar
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
+    def config = new Sorter.Config(true)
+    def sorter = GroovySorter.of(buildScript, config, lineSeparator)
+
+    expect:
+    !sorter.isSorted()
+    sorter.rewritten() == expected
+
+    when:
+    Files.writeString(buildScript, expected)
+    def sorted = GroovySorter.of(buildScript, config, lineSeparator)
+
+    then:
+    sorted.isSorted()
+
+    when:
+    sorted.rewritten()
+
+    then:
+    thrown(AlreadyOrderedException)
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
+  def "issue 164 leaves configuration spacing alone when blank lines are disabled"() {
+    given:
+    def buildScript = dir.resolve('build.gradle')
+    def fileContent = normalize('''\
+      dependencies{
+          api libs.foo
+          implementation 'g:bar:1'
+
+
+          testImplementation libs.baz
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContent)
+    def sorter = GroovySorter.of(buildScript, new Sorter.Config(false), lineSeparator)
+
+    expect:
+    sorter.isSorted()
+    Files.readString(buildScript) == fileContent
+
+    when:
+    sorter.rewritten()
+
+    then:
+    thrown(AlreadyOrderedException)
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
   def "will not sort already sorted build script"() {
     given:
     def buildScript = dir.resolve('build.gradle')

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -420,6 +420,145 @@ class KotlinSorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
+  def "issue 164 inserts only missing configuration blank lines in sorted blocks"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContents = normalize('''\
+      dependencies{
+          api(libs.foo) // Keep this trailing comment in place.
+          /* Keep this multiline comment with the implementation dependency.
+
+             Its internal blank line is not configuration separation. */
+          implementation("g:bar:1")
+
+          testImplementation(libs.baz)
+      }
+
+      dependencies {
+        api("g:foo:1")
+
+        implementation(libs.bar)
+      }
+      ''', lineSeparator)
+    def expected = normalize('''\
+      dependencies{
+          api(libs.foo) // Keep this trailing comment in place.
+
+          /* Keep this multiline comment with the implementation dependency.
+
+             Its internal blank line is not configuration separation. */
+          implementation("g:bar:1")
+
+          testImplementation(libs.baz)
+      }
+
+      dependencies {
+        api("g:foo:1")
+
+        implementation(libs.bar)
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
+    def config = new Sorter.Config(true)
+    def sorter = KotlinSorter.of(buildScript, config, lineSeparator)
+
+    expect:
+    !sorter.isSorted()
+    sorter.rewritten() == expected
+
+    when:
+    Files.writeString(buildScript, expected)
+    def sorted = KotlinSorter.of(buildScript, config, lineSeparator)
+
+    then:
+    sorted.isSorted()
+
+    when:
+    sorted.rewritten()
+
+    then:
+    thrown(AlreadyOrderedException)
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
+  def "issue 164 leaves configuration spacing alone when blank lines are disabled"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContents = normalize('''\
+      dependencies{
+          api(libs.foo)
+          implementation("g:bar:1")
+
+
+          testImplementation(libs.baz)
+      }
+      ''', lineSeparator)
+    Files.writeString(buildScript, fileContents)
+    def sorter = KotlinSorter.of(buildScript, new Sorter.Config(false), lineSeparator)
+
+    expect:
+    sorter.isSorted()
+    Files.readString(buildScript) == fileContents
+
+    when:
+    sorter.rewritten()
+
+    then:
+    thrown(AlreadyOrderedException)
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
+  def "issue 164 rewrites same-line configuration groups canonically"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    Files.writeString(buildScript, '''\
+      dependencies {
+        api("g:a:1"); implementation("g:b:1")
+      }
+      '''.stripIndent())
+    def sorter = KotlinSorter.of(buildScript, new Sorter.Config(true), '\n')
+
+    expect:
+    !sorter.isSorted()
+    sorter.rewritten() == '''\
+      dependencies {
+        api("g:a:1")
+
+        implementation("g:b:1")
+      }
+      '''.stripIndent()
+  }
+
+  def "issue 164 ignores configuration groups separated by other syntax"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContents = '''\
+      dependencies {
+        api("g:a:1")
+        constraints {
+          // Unrelated syntax remains untouched.
+        }
+        implementation("g:b:1")
+      }
+      '''.stripIndent()
+    Files.writeString(buildScript, fileContents)
+    def sorter = KotlinSorter.of(buildScript, new Sorter.Config(true), '\n')
+
+    expect:
+    sorter.isSorted()
+    Files.readString(buildScript) == fileContents
+
+    when:
+    sorter.rewritten()
+
+    then:
+    thrown(AlreadyOrderedException)
+  }
+
   def "will not sort already sorted build script"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')


### PR DESCRIPTION
Fixes #164

## Summary

- insert configured blank lines between dependency configuration groups even when the declarations are already sorted
- preserve existing comments, indentation, line separators, and unrelated statements by applying token-level edits when safe
- fall back to the existing canonical block rewrite for valid same-line Kotlin declarations

## Validation

- `./gradlew :sort:check --no-scan --rerun-tasks`
- `./gradlew check --no-scan --no-build-cache --rerun-tasks --console=plain`
- `git diff --check`
