### PR TITLE
Sort nested project paths after hyphenated siblings

### DIFF
--- a/sort/src/main/kotlin/com/squareup/sort/DependencyDeclaration.kt
+++ b/sort/src/main/kotlin/com/squareup/sort/DependencyDeclaration.kt
@@ -32,21 +32,25 @@ internal interface DependencyDeclaration {
   fun comparisonText(): String
 
   /**
-   * Colons should sort "higher" than hyphens. The comma's ASCII value
-   * is 44, the hyphen's is 45, and the colon's is 58. We replace
-   * colons with commas and then rely on natural sort order from
-   * there.
+   * Colons in external dependency coordinates should sort "higher" than hyphens. The comma's ASCII
+   * value is 44, the hyphen's is 45, and the colon's is 58. We replace those colons with commas and
+   * then rely on natural sort order from there.
    *
-   * For example, consider ':foo-bar' vs. ':foo:bar'. Before this
-   * transformation, ':foo-bar' will appear before ':foo:bar'. But
-   * after it, we compare ',foo,bar' to ',foo-bar', which gives the
-   * desired sort ordering.
+   * For example, consider 'foo-bar:baz' vs. 'foo:bar:baz'. Before this transformation,
+   * 'foo-bar:baz' will appear before 'foo:bar:baz'. But after it, we compare 'foo-bar,baz' to
+   * 'foo,bar,baz', which gives the desired sort ordering.
    *
-   * Similarly, single and double quotes have different ASCII values,
-   * but we don't care about that for our purposes.
+   * Project path colons remain unchanged so nested paths sort after hyphenated sibling paths.
+   * Similarly, single and double quotes have different ASCII values, but we don't care about that
+   * for our purposes.
    */
   fun String.replaceHyphens(): String {
     // TODO maybe I should make this an ABC and this function protected.
-    return replace(':', ',').replace("'", "\"")
+    val normalizedQuotes = replace("'", "\"")
+    return if (this@DependencyDeclaration.isProjectDependency()) {
+      normalizedQuotes
+    } else {
+      normalizedQuotes.replace(':', ',')
+    }
   }
 }

--- a/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/GroovySorterSpec.groovy
@@ -314,13 +314,20 @@ final class GroovySorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
-  def "colons have higher precedence than hyphen"() {
+  def "project path separators sort after hyphens without changing external coordinates"() {
     given:
     def buildScript = dir.resolve('build.gradle')
     def fileContent = normalize('''\
           dependencies {
-            api project(":marvin-robot:so-sad")
-            api project(":marvin:robot:so-sad")
+            api project(":feature:foo:shared")
+            api project(":feature:foo-v2")
+            api project(":feature:foo")
+            api project("relative:foo:shared")
+            api project("relative:foo-v2")
+            api ":foo-bar:baz"
+            api "foo-bar:baz"
+            api ":foo:bar-baz"
+            api "foo:bar:baz"
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContent)
@@ -332,8 +339,15 @@ final class GroovySorterSpec extends Specification {
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
-            api project(":marvin:robot:so-sad")
-            api project(":marvin-robot:so-sad")
+            api project(":feature:foo")
+            api project(":feature:foo-v2")
+            api project(":feature:foo:shared")
+            api project("relative:foo-v2")
+            api project("relative:foo:shared")
+            api ":foo:bar-baz"
+            api ":foo-bar:baz"
+            api "foo:bar:baz"
+            api "foo-bar:baz"
           }
         '''.stripIndent()
     )).inOrder()

--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -356,13 +356,20 @@ class KotlinSorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
-  def "colons have higher precedence than hyphen"() {
+  def "project path separators sort after hyphens without changing external coordinates"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')
     def fileContents = normalize('''\
           dependencies {
-            api(project(":marvin-robot:so-sad"))
-            api(project(":marvin:robot:so-sad"))
+            api(project(":feature:foo:shared"))
+            api(project(":feature:foo-v2"))
+            api(project(":feature:foo"))
+            api(project("relative:foo:shared"))
+            api(project("relative:foo-v2"))
+            api(":foo-bar:baz")
+            api("foo-bar:baz")
+            api(":foo:bar-baz")
+            api("foo:bar:baz")
           }
         ''', lineSeparator)
     Files.writeString(buildScript, fileContents)
@@ -374,8 +381,15 @@ class KotlinSorterSpec extends Specification {
     assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
       '''\
           dependencies {
-            api(project(":marvin:robot:so-sad"))
-            api(project(":marvin-robot:so-sad"))
+            api(project(":feature:foo"))
+            api(project(":feature:foo-v2"))
+            api(project(":feature:foo:shared"))
+            api(project("relative:foo-v2"))
+            api(project("relative:foo:shared"))
+            api(":foo:bar-baz")
+            api(":foo-bar:baz")
+            api("foo:bar:baz")
+            api("foo-bar:baz")
           }
         '''.stripIndent()
     )).inOrder()


### PR DESCRIPTION
Fixes #130

## Summary

- preserve project path separators when computing dependency sort order
- retain the existing colon precedence for external dependency coordinates
- cover absolute and relative project paths in both Groovy and Kotlin DSLs

## Validation

- `./gradlew :sort:test --tests 'com.squareup.sort.GroovySorterSpec' --tests 'com.squareup.sort.KotlinSorterSpec' --no-daemon`
- `./gradlew check -s --no-daemon`
- `git diff --check`
