### PR TITLE
test: cover project-qualified BOM dependencies

### DIFF
--- a/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
+++ b/sort/src/test/groovy/com/squareup/sort/KotlinSorterSpec.groovy
@@ -164,6 +164,37 @@ class KotlinSorterSpec extends Specification {
     lineSeparator << ['\n', '\r\n']
   }
 
+  def "can sort a BOM qualified by project dependencies"() {
+    given:
+    def buildScript = dir.resolve('build.gradle.kts')
+    def fileContent = normalize(
+      '''\
+          dependencies {
+            implementation(libs.ktor.client.core)
+            implementation(project.dependencies.platform(libs.ktor.bom))
+            implementation(libs.koin.core)
+          }''',
+      lineSeparator
+    )
+    Files.writeString(buildScript, fileContent)
+    def config = new Sorter.Config(true)
+    def sorter = KotlinSorter.of(buildScript, config, lineSeparator)
+
+    expect:
+    extractLineSeparators(sorter.rewritten()).every { it == lineSeparator }
+    assertThat(trimmedLinesOf(sorter.rewritten())).containsExactlyElementsIn(trimmedLinesOf(
+      '''\
+          dependencies {
+            implementation(project.dependencies.platform(libs.ktor.bom))
+            implementation(libs.koin.core)
+            implementation(libs.ktor.client.core)
+          }'''.stripIndent()
+    )).inOrder()
+
+    where:
+    lineSeparator << ['\n', '\r\n']
+  }
+
   def "can sort testFixtures correctly"() {
     given:
     def buildScript = dir.resolve('build.gradle.kts')


### PR DESCRIPTION
Closes #112

## Summary

- add regression coverage for a BOM qualified through `project.dependencies.platform`
- verify the expression is retained while the dependency block is reordered
- cover both LF and CRLF build scripts

The underlying parser crash was resolved by the kotlin-editor 0.22 upgrade. This test preserves coverage for the original issue syntax without adding a production workaround.

## Validation

- focused regression against historical kotlin-editor 0.21 (fails with the reported exception)
- focused regression on current kotlin-editor 0.24
- `./gradlew check -s --no-daemon`
- `git diff --check`
